### PR TITLE
support dates (INT64 only) in plain encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,18 @@ For instance, to read a file `c:\test.parquet` you woudl normally write the foll
 ```csharp
 using System.IO;
 using Parquet;
+using Parquet.Data;
 
 using(Stream fs = File.OpenRead("c:\\test.parquet"))
 {
 	using(var reader = new ParquetReader(fs))
 	{
-		ParquetDataSet ds = reader.Read();
+		DataSet ds = reader.Read();
 	}
 }
 ```
 
-this will read entire file in memory as a set of columns inside `ParquetDataSet` class.
+this will read entire file in memory as a set of rows inside `DataSet` class.
 
 ### Writing files
 
@@ -58,20 +59,21 @@ Parquet.Net operates on streams, therefore you need to create it first. The foll
 ```csharp
 using System.IO;
 using Parquet;
+using Parquet.Data;
 
-var idColumn = new ParquetColumn<int>("id");
-idColumn.Add(1, 2);
+var ds = new DataSet(
+	new SchemaElement<int>("id", false),
+	new SchemaElement<string>("city", false)
+);
 
-var cityColumn = new ParquetColumn<string>("city");
-cityColumn.Add("London", "Derby");
-
-var dataSet = new ParquetDataSet(idColumn, cityColumn);
+ds.Add(1, "London");
+ds.Add(2, "Derby");
 
 using(Stream fileStream = File.OpenWrite("c:\\test.parquet"))
 {
 	using(var writer = new ParquetWriter(fileStream))
 	{
-		writer.Write(dataSet);
+		writer.Write(ds);
 	}
 }
 

--- a/src/Parquet.Test/File/Values/PlainValuesReaderWriterTest.cs
+++ b/src/Parquet.Test/File/Values/PlainValuesReaderWriterTest.cs
@@ -1,5 +1,6 @@
 ﻿using Parquet.Data;
 using Parquet.File.Values;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -29,7 +30,7 @@ namespace Parquet.Test.File.Values
       }
 
       [Fact]
-      public void Booleans()
+      public void Array_of_booleans_writes_and_reads()
       {
          var bools = new List<bool>();
          bools.AddRange(new[] { true, false, true });
@@ -44,6 +45,22 @@ namespace Parquet.Test.File.Values
          _reader.Read(_br, schema, boolsRead, 3);
 
          Assert.Equal(bools, boolsRead.Cast<bool>().ToList());
+      }
+
+      [Fact]
+      public void DateTimeOffset_writes_and_reads()
+      {
+         var dates = new List<DateTimeOffset> { DateTime.UtcNow.RoundToSecond() };  //this version doesn't store milliseconds
+         var schema = new SchemaElement<DateTimeOffset>("dto", false);
+
+         _writer.Write(_bw, schema, dates);
+
+         _ms.Position = 0;
+
+         var datesRead = new List<DateTimeOffset>();
+         _reader.Read(_br, schema, datesRead, 1);
+
+         Assert.Equal(datesRead[0], dates[0]);
       }
    }
 }

--- a/src/Parquet.Test/Reader/ParquetCsvComparison.cs
+++ b/src/Parquet.Test/Reader/ParquetCsvComparison.cs
@@ -104,7 +104,7 @@ namespace Parquet.Test.Reader
       private DataSet ReadParquet(string name)
       {
          string path = GetDataFilePath(name);
-         return ParquetReader.ReadFile(path);
+         return ParquetReader.ReadFile(path, new ParquetOptions { TreatByteArrayAsString = true });
       }
 
       private DataSet ReadCsv(string name)

--- a/src/Parquet/Data/SchemaElement.cs
+++ b/src/Parquet/Data/SchemaElement.cs
@@ -72,6 +72,12 @@ namespace Parquet.Data
 
       internal PSE Thrift { get; set; }
 
+      internal bool IsAnnotatedWith(Thrift.ConvertedType ct)
+      {
+         //checking __isset is important, this is a way of Thrift to tell whether the variable is set at all
+         return Thrift.__isset.converted_type && Thrift.Converted_type == ct;
+      }
+
       /// <summary>
       /// Pretty prints
       /// </summary>

--- a/src/Parquet/ParquetOptions.cs
+++ b/src/Parquet/ParquetOptions.cs
@@ -6,8 +6,23 @@
    public class ParquetOptions
    {
       /// <summary>
+      /// Initializes a new instance of the <see cref="ParquetOptions"/> class.
+      /// </summary>
+      public ParquetOptions()
+      {
+         TreatByteArrayAsString = false;
+
+         TreatBigIntegersAsDates = true;
+      }
+
+      /// <summary>
       /// When true byte arrays will be treated as UTF-8 strings
       /// </summary>
       public bool TreatByteArrayAsString { get; set; }
+
+      /// <summary>
+      /// Gets or sets a value indicating whether big integers are always treated as dates
+      /// </summary>
+      public bool TreatBigIntegersAsDates { get; set; }
    }
 }

--- a/src/Parquet/ParquetReader.cs
+++ b/src/Parquet/ParquetReader.cs
@@ -39,13 +39,14 @@ namespace Parquet
       private readonly BinaryReader _reader;
       private readonly ThriftStream _thrift;
       private Thrift.FileMetaData _meta;
-      private readonly ParquetOptions _options = new ParquetOptions();
+      private readonly ParquetOptions _options;
 
       /// <summary>
       /// Creates an instance from input stream
       /// </summary>
-      /// <param name="input"></param>
-      public ParquetReader(Stream input)
+      /// <param name="input">Input stream, must be readable and seekable</param>
+      /// <param name="options">Optional reader options</param>
+      public ParquetReader(Stream input, ParquetOptions options = null)
       {
          _input = input ?? throw new ArgumentNullException(nameof(input));
          if (!input.CanRead || !input.CanSeek) throw new ArgumentException("stream must be readable and seekable", nameof(input));
@@ -54,13 +55,20 @@ namespace Parquet
          _reader = new BinaryReader(input);
          ValidateFile();
          _thrift = new ThriftStream(input);
+         _options = options ?? new ParquetOptions();
       }
 
-      public static DataSet ReadFile(string fullPath)
+      /// <summary>
+      /// Reads the file
+      /// </summary>
+      /// <param name="fullPath">The full path.</param>
+      /// <param name="options">Optional reader options.</param>
+      /// <returns>DataSet</returns>
+      public static DataSet ReadFile(string fullPath, ParquetOptions options = null)
       {
          using (Stream fs = System.IO.File.OpenRead(fullPath))
          {
-            using (var reader = new ParquetReader(fs))
+            using (var reader = new ParquetReader(fs, options))
             {
                return reader.Read();
             }

--- a/src/Parquet/ParquetUtils.cs
+++ b/src/Parquet/ParquetUtils.cs
@@ -29,66 +29,72 @@ using System.Text;
 
 namespace Parquet
 {
-    static class ParquetUtils
-    {
-       public static bool[] ConvertToBoolArray(this BitArray bits, int bitCount)
-       {
-          var boolList = new List<bool>();
-          for (int index = 0; index < bitCount; index++)
-          {
-             boolList.Add(bits.Get(index));
-          }
+   static class ParquetUtils
+   {
+      private static readonly DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
-          return boolList.ToArray();
-       }
+      public static bool[] ConvertToBoolArray(this BitArray bits, int bitCount)
+      {
+         var boolList = new List<bool>();
+         for (int index = 0; index < bitCount; index++)
+         {
+            boolList.Add(bits.Get(index));
+         }
 
-       public static Byte GetByte(this BitArray array)
-       {
-          Byte byt = 0;
-          for (int i = array.Length - 1; i >= 0; i--)
-             byt = (byte)((byt << 1) | (array[i] ? 1 : 0));
-          return byt;
-       }
+         return boolList.ToArray();
+      }
 
-       // ReSharper disable once InconsistentNaming
-       public static int GetByteArrayLELength(byte[] len)
-       {
-          int output = BitConverter.ToInt32(len, 0);
-          return output;
-       }
+      public static Byte GetByte(this BitArray array)
+      {
+         Byte byt = 0;
+         for (int i = array.Length - 1; i >= 0; i--)
+            byt = (byte)((byt << 1) | (array[i] ? 1 : 0));
+         return byt;
+      }
 
-       public static DateTime FromUnixTime(this int unixTime)
-       {
-          var epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-          return epoch.AddDays(unixTime);
-       }
+      // ReSharper disable once InconsistentNaming
+      public static int GetByteArrayLELength(byte[] len)
+      {
+         int output = BitConverter.ToInt32(len, 0);
+         return output;
+      }
 
-       public static DateTime FromUnixTime(this long unixTime)
-       {
-          var epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-          return epoch.AddSeconds(unixTime);
-       }
+      public static DateTime FromUnixTime(this int unixTime)
+      {
+         var epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+         return epoch.AddDays(unixTime);
+      }
 
-      public static long ToUnixTime(this DateTime date)
-       {
-          var epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-          return Convert.ToInt64((date - epoch).TotalSeconds);
-       }
+      public static DateTime FromUnixTime(this long unixTime)
+      {
+         return UnixEpoch.AddSeconds(unixTime);
+      }
 
-       public static long GetUnixUnixTimeDays(this DateTime date)
-       {
-          var epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-          return Convert.ToInt64((date - epoch).TotalDays);
-       }
+      public static long ToUnixTime(this DateTimeOffset date)
+      {
+         return Convert.ToInt64((date - UnixEpoch).TotalSeconds);
+      }
+
+      public static double ToUnixDays(this DateTimeOffset dto)
+      {
+         TimeSpan diff = dto - UnixEpoch;
+         return diff.TotalDays;
+      }
+
+      public static long GetUnixUnixTimeDays(this DateTime date)
+      {
+         var epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+         return Convert.ToInt64((date - epoch).TotalDays);
+      }
 
       public static DateTime JulianToDateTime(this int julianDate)
-       {
+      {
          double unixTime = julianDate - 2440587;
          DateTime dtDateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, System.DateTimeKind.Utc);
          dtDateTime = dtDateTime.AddDays(unixTime - 1).ToLocalTime();
 
-          return dtDateTime;
-       }
+         return dtDateTime;
+      }
 
    }
 
@@ -97,10 +103,10 @@ namespace Parquet
       public byte[] IntToLittleEndian(int data)
       {
          byte[] b = new byte[4];
-         b[0] = (byte) data;
-         b[1] = (byte) (((uint) data >> 8) & 0xFF);
-         b[2] = (byte) (((uint) data >> 16) & 0xFF);
-         b[3] = (byte) (((uint) data >> 24) & 0xFF);
+         b[0] = (byte)data;
+         b[1] = (byte)(((uint)data >> 8) & 0xFF);
+         b[2] = (byte)(((uint)data >> 16) & 0xFF);
+         b[3] = (byte)(((uint)data >> 24) & 0xFF);
 
          return b;
       }
@@ -112,13 +118,13 @@ namespace Parquet
 
          for (int i = 0; i < 8; i++)
          {
-            b[i] = (byte) (data & 0xFF);
+            b[i] = (byte)(data & 0xFF);
             data >>= 8;
          }
 
          return b;
       }
-      
+
 
       public byte[] DoubleToLittleEndian(double data)
       {


### PR DESCRIPTION
### Fixes

Issue #81 

### Description

This supports dates in plain encoding, IN64 resolution only (up to seconds)

### Todos
- [x] unit/integration tests
- [x] documentation
