### PR TITLE
87 read interval type

### DIFF
--- a/src/Parquet.Test/EndToEndTypeTest.cs
+++ b/src/Parquet.Test/EndToEndTypeTest.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using Parquet.File.Values;
 using Xunit;
 using Xunit.Extensions;
 
@@ -14,8 +15,8 @@ namespace Parquet.Test
       {
          new object[] {  new SchemaElement<string>("s"), "plain string" },
          new object[] {  new SchemaElement<string>("s"), "L'Oréal Paris" },
-         new object[] {  new SchemaElement<float>("f"), (float)1.23 },
-         new object[] {  new SchemaElement<double>("d"), (double)10.44 },
+         new object[] {  new SchemaElement<float>("f"), 1.23f },
+         new object[] {  new SchemaElement<double>("d"), 10.44D },
 
          //loses precision slightly, i.e.
          //Expected: 2017-07-13T10:58:44.3767154+00:00
@@ -25,7 +26,8 @@ namespace Parquet.Test
 
          new object[] {  new DateTimeSchemaElement("d", DateTimeFormat.DateAndTime), new DateTimeOffset(DateTime.UtcNow.RoundToSecond()) },
          // don't want any excess info in the offset INT32 doesn't contain or care about this data 
-         new object[] {  new DateTimeSchemaElement("d", DateTimeFormat.Date), new DateTimeOffset(DateTime.UtcNow.RoundToDay(), TimeSpan.Zero) }
+         new object[] {  new DateTimeSchemaElement("d", DateTimeFormat.Date), new DateTimeOffset(DateTime.UtcNow.RoundToDay(), TimeSpan.Zero) },
+         new object[] {  new IntervalSchemaElement("interval"), new Interval(3, 2, 1) }
       };
 
       [Theory]

--- a/src/Parquet/Data/SchemaElement.cs
+++ b/src/Parquet/Data/SchemaElement.cs
@@ -83,8 +83,8 @@ namespace Parquet.Data
       /// </summary>
       public bool IsNullable
       {
-         get { return Thrift.Repetition_type != Parquet.Thrift.FieldRepetitionType.REQUIRED; }
-         set { Thrift.Repetition_type = value ? Parquet.Thrift.FieldRepetitionType.OPTIONAL : Parquet.Thrift.FieldRepetitionType.REQUIRED; }
+         get => Thrift.Repetition_type != Parquet.Thrift.FieldRepetitionType.REQUIRED;
+         set => Thrift.Repetition_type = value ? Parquet.Thrift.FieldRepetitionType.OPTIONAL : Parquet.Thrift.FieldRepetitionType.REQUIRED;
       }
 
       internal Thrift.SchemaElement Thrift { get; set; }

--- a/src/Parquet/File/Values/BigDecimal.cs
+++ b/src/Parquet/File/Values/BigDecimal.cs
@@ -2,12 +2,29 @@ using System.Numerics;
 
 namespace Parquet.File.Values
 {
+   /// <summary>
+   /// A class that encapsulates BigDecimal like the java class
+   /// </summary>
    struct BigDecimal
    {
+      /// <summary>
+      /// Contains a Decimal value that is the big integer
+      /// </summary>
       public decimal Integer { get; set; }
+      /// <summary>
+      /// The scale of the decimal value
+      /// </summary>
       public int Scale { get; set; }
+      /// <summary>
+      /// The precision of the decimal value
+      /// </summary>
       public int Precision { get; set; }
-
+      /// <summary>
+      /// Used to construct a BigDecimal
+      /// </summary>
+      /// <param name="integer">The <c ref="BigInteger"></c> value</param>
+      /// <param name="scale">The scale of the decimal</param>
+      /// <param name="precision">The precision of the decimal</param>
       public BigDecimal(BigInteger integer, int scale, int precision) : this()
       {
          Integer = (decimal) integer;
@@ -20,7 +37,10 @@ namespace Parquet.File.Values
          }
          Scale = scale;
       }
-
+      /// <summary>
+      /// Converts a BigDecimal to a decimal
+      /// </summary>
+      /// <param name="bd">The BigDecimal value</param>
       public static explicit operator decimal(BigDecimal bd)
       {
          return bd.Integer;

--- a/src/Parquet/File/Values/Interval.cs
+++ b/src/Parquet/File/Values/Interval.cs
@@ -1,0 +1,34 @@
+namespace Parquet.File.Values
+{
+   /// <summary>
+   /// A parquet interval type compatible with a Spark INTERVAL type
+   /// 12 byte little Endian structure fits in an INT96 original type with an INTERVAL converted type
+   /// </summary>
+   struct Interval
+   {
+      /// <summary>
+      /// Used to create an interval type
+      /// </summary>
+      /// <param name="months">The month interval</param>
+      /// <param name="days">The days interval</param>
+      /// <param name="millis">The milliseconds interval</param>
+      public Interval(int months, int days, int millis)
+      {
+         Months = months;
+         Days = days;
+         Millis = millis;
+      }
+      /// <summary>
+      /// Returns the number of milliseconds in the type
+      /// </summary>
+      public int Millis { get; set; }
+      /// <summary>
+      /// Returns the number of days in the type
+      /// </summary>
+      public int Days { get; set; }
+      /// <summary>
+      /// Returns the number of months in type
+      /// </summary>
+      public int Months { get; set; }
+   }
+}

--- a/src/Parquet/File/Values/PlainValuesReader.cs
+++ b/src/Parquet/File/Values/PlainValuesReader.cs
@@ -178,7 +178,7 @@ namespace Parquet.File.Values
                byte[] nanos = new byte[8];
                Array.Copy(data, i + 8, v96, 0, 4);
                Array.Copy(data, i, nanos, 0, 8);
-               DateTime bi = BitConverter.ToInt32(v96, 0).JulianToDateTime();
+               DateTime bi = (BitConverter.ToInt32(v96, 0) - 1).JulianToDateTime();
                long nanosToInt64 = BitConverter.ToInt64(nanos, 0);
                double millis = (double) nanosToInt64 / 1000000D;
                bi = bi.AddMilliseconds(millis);

--- a/src/Parquet/File/Values/PlainValuesReader.cs
+++ b/src/Parquet/File/Values/PlainValuesReader.cs
@@ -160,36 +160,30 @@ namespace Parquet.File.Values
       }
 
       [MethodImpl(MethodImplOptions.AggressiveInlining)]
-      private static void ReadInt96(byte[] data, SchemaElement schema, IList destination)
+      private void ReadInt96(byte[] data, SchemaElement schema, IList destination)
       {
-
-
-#if !SPARK_TYPES
-         //var r96 = new List<BigInteger>(data.Length / 12);
-#else
-         //var r96 = new List<DateTimeOffset?>(data.Length / 12);
-#endif
-
          for (int i = 0; i < data.Length; i += 12)
          {
 
-#if !SPARK_TYPES
-            byte[] v96 = new byte[12];
-            Array.Copy(data, i, v96, 0, 12);
-            var bi = new BigInteger(v96);
-#else
-            // for the time being we can discard the nanos 
-            byte[] v96 = new byte[4];
-            byte[] nanos = new byte[8];
-            Array.Copy(data, i + 8, v96, 0, 4);
-            Array.Copy(data, i, nanos, 0, 8);
-            DateTime bi = BitConverter.ToInt32(v96, 0).JulianToDateTime();
-            long nanosToInt64 = BitConverter.ToInt64(nanos, 0);
-            double millis = (double) nanosToInt64 / 1000000D;
-            bi = bi.AddMilliseconds(millis);
-#endif
-            destination.Add(new DateTimeOffset(bi));
-
+            if (!_options.TreatBigIntegersAsDates)
+            {
+               byte[] v96 = new byte[12];
+               Array.Copy(data, i, v96, 0, 12);;
+               destination.Add(new BigInteger(v96));
+            }
+            else
+            {
+               // for the time being we can discard the nanos 
+               byte[] v96 = new byte[4];
+               byte[] nanos = new byte[8];
+               Array.Copy(data, i + 8, v96, 0, 4);
+               Array.Copy(data, i, nanos, 0, 8);
+               DateTime bi = BitConverter.ToInt32(v96, 0).JulianToDateTime();
+               long nanosToInt64 = BitConverter.ToInt64(nanos, 0);
+               double millis = (double) nanosToInt64 / 1000000D;
+               bi = bi.AddMilliseconds(millis);
+               destination.Add(new DateTimeOffset(bi));
+            }
          } 
       }
 

--- a/src/Parquet/File/Values/PlainValuesWriter.cs
+++ b/src/Parquet/File/Values/PlainValuesWriter.cs
@@ -196,6 +196,16 @@ namespace Parquet.File.Values
                Write(writer, s);
             }
          }
+         else if (elementType == typeof(Interval))
+         {
+            var src = (List<Interval>) data;
+            foreach (var interval in src)
+            {
+               writer.Write(BitConverter.GetBytes(interval.Months));
+               writer.Write(BitConverter.GetBytes(interval.Days));
+               writer.Write(BitConverter.GetBytes(interval.Millis));
+            }
+         }
          else if(elementType == typeof(byte[]))
          {
             var src = (List<byte[]>)data;


### PR DESCRIPTION
### Fixes

Issue #87

### Description

Supports the reading and writing of interval types. Not yet implemented in Spark so followed Parquet spec months (4 bytes LE) / days (4 bytes LE) / millis (4 bytes LE) with annotated INTERVAL on FIXED_LEN_BYTE_ARRAY

### Todos
- [ ] unit/integration tests
- [ ] documentation
