### PR TITLE
#124 visual representation of nullity which is configurable with Disp…

### DIFF
--- a/src/parq/AppSettings.cs
+++ b/src/parq/AppSettings.cs
@@ -13,6 +13,8 @@ namespace parq
 
       public readonly Option<string> Mode = new Option<string>("interactive");
 
+      public readonly Option<bool> DisplayNulls = new Option<bool>(true);
+
       //singleton
       private static AppSettings instance;
       public static AppSettings Instance => instance ?? (instance = new AppSettings());

--- a/src/parq/Display/Models/ColumnDetails.cs
+++ b/src/parq/Display/Models/ColumnDetails.cs
@@ -13,8 +13,19 @@ namespace parq.Display.Models
       {
          var value = Convert.ToString(rawValue);
          var formatted = new StringBuilder();
-         var padReq = columnWidth - value.Length;
 
+         if (AppSettings.Instance.DisplayNulls && rawValue == null)
+         {
+            for (int k = 0; k < columnWidth - 6; k++)
+            {
+               formatted.Append(" ");
+            }
+            formatted.Append("[null]");
+
+            return formatted.ToString();
+         }
+
+         var padReq = columnWidth - value.Length;
          if (padReq > 0)
          {
             for (int k = 0; k < padReq; k++)

--- a/src/parq/Display/Views/InteractiveConsoleView.cs
+++ b/src/parq/Display/Views/InteractiveConsoleView.cs
@@ -238,7 +238,19 @@ namespace parq.Display.Views
                var header = viewModel.Columns.ElementAt(j);
                if (columnsFitToScreen.Columns.Contains(header))
                {
-                  Console.Write(header.GetFormattedValue(row[j]));
+                  var data = header.GetFormattedValue(row[j]);
+
+                  if (data.Contains("[null]"))
+                  {
+                     Console.ForegroundColor = ConsoleColor.DarkGray;
+                     Console.Write(data);
+                     Console.ResetColor();
+                  }
+                  else
+                  {
+                     Console.Write(data);
+                  }
+
                   Console.Write(verticalSeparator);
                }
             }


### PR DESCRIPTION
…layNulls=true(default)/false

### Fixes

Issue #124 

### Description

Nulls now show up as [null] and colour in interactive mode.

### Todos
- [ ] unit/integration tests
- [ ] documentation
