### PR TITLE
added new parquet-utils with optional summary stats

### DIFF
--- a/src/Parquet.Test/Parquet.Test.csproj
+++ b/src/Parquet.Test/Parquet.Test.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\parquet-utils\parquet-utils.csproj" />
     <ProjectReference Include="..\Parquet\Parquet.csproj" />
   </ItemGroup>
 

--- a/src/Parquet.Test/utils/DataSetSummaryTest.cs
+++ b/src/Parquet.Test/utils/DataSetSummaryTest.cs
@@ -1,0 +1,67 @@
+﻿using Parquet.Data;
+using System;
+using Xunit;
+
+namespace Parquet.Test
+{
+   public class DataSetSummaryTest
+   {
+      [Fact]
+      public void Check_datasetstats_numerical_max()
+      {
+         var ds = new DataSet(new SchemaElement<string>("s"), new SchemaElement<int>("i"),
+            new SchemaElement<float>("f")) { { "1", 2, 3F }, { "1", 3, 4F }, { "1", 4, 5F } };
+
+         var summary = new DataSetSummaryStats(ds);
+         Assert.Equal(4, summary.GetColumnStats(1).Max);
+         Assert.Equal(5, summary.GetColumnStats(2).Max);
+      }
+
+      [Fact]
+      public void Check_datasetstats_numerical_min()
+      {
+         var ds = new DataSet(new SchemaElement<string>("s"), new SchemaElement<int>("i"),
+            new SchemaElement<float>("f")) { { "1", 2, 3F }, { "1", 3, 4F }, { "1", 4, 5F } };
+
+         var summary = new DataSetSummaryStats(ds);
+
+         Assert.Equal(2, summary.GetColumnStats(1).Min);
+         Assert.Equal(3, summary.GetColumnStats(2).Min);
+      }
+
+      [Fact]
+      public void Check_datasetstats_numerical_mean()
+      {
+         var ds = new DataSet(new SchemaElement<string>("s"), new SchemaElement<int>("i"),
+            new SchemaElement<float>("f")) { { "1", 2, 3.2F }, { "1", 3, 4F }, { "1", 4, 5F } };
+
+         var summary = new DataSetSummaryStats(ds);
+         Assert.Equal(3, summary.GetColumnStats(1).Mean);
+         Assert.Equal(4.07, Math.Round(summary.GetColumnStats(2).Mean, 2));
+      }
+
+      [Fact]
+      public void Check_datasetstats_numerical_sd()
+      {
+         var ds = new DataSet(new SchemaElement<string>("s"), new SchemaElement<int>("i"),
+            new SchemaElement<float>("f")) { { "1", 2, 3.2F }, { "1", 3, 4F }, { "1", 4, 5F } };
+
+         var summary = new DataSetSummaryStats(ds);
+         Assert.Equal(1, summary.GetColumnStats(1).StandardDeviation);
+         Assert.Equal(0.9, Math.Round(summary.GetColumnStats(2).StandardDeviation, 2));
+      }
+
+      [Fact]
+      public void Check_datasetstats_numerical_nulls()
+      {
+         var ds = new DataSet(new SchemaElement<string>("s"), new SchemaElement<int>("i"),
+            new SchemaElement<float>("f")) { { "1", 2, null }, { null, null, 4F }, { "1", 4, null } };
+
+         var summary = new DataSetSummaryStats(ds);
+         Assert.Equal(1, summary.GetColumnStats(0).NullCount);
+         Assert.Equal(0, summary.GetColumnStats(0).Mean);
+         Assert.Equal(1, summary.GetColumnStats(1).NullCount);
+         Assert.Equal(2, summary.GetColumnStats(2).NullCount);
+      }
+   }
+}

--- a/src/Parquet.sln
+++ b/src/Parquet.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.0
+VisualStudioVersion = 15.0.26430.15
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Parquet", "Parquet\Parquet.csproj", "{A0507D42-940E-4EF9-BD33-46BB6561A2F5}"
 EndProject
@@ -39,6 +39,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{3F47B841-9
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Parquet.Runner", "Parquet.Runner\Parquet.Runner.csproj", "{CBF02EBF-EB36-42AA-8557-B95CEF5FD175}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "parquet-utils", "parquet-utils\parquet-utils.csproj", "{5C81C1DB-EE29-41B7-8AC8-7730C03FEB06}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -61,6 +63,10 @@ Global
 		{CBF02EBF-EB36-42AA-8557-B95CEF5FD175}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CBF02EBF-EB36-42AA-8557-B95CEF5FD175}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CBF02EBF-EB36-42AA-8557-B95CEF5FD175}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5C81C1DB-EE29-41B7-8AC8-7730C03FEB06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5C81C1DB-EE29-41B7-8AC8-7730C03FEB06}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5C81C1DB-EE29-41B7-8AC8-7730C03FEB06}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5C81C1DB-EE29-41B7-8AC8-7730C03FEB06}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -69,5 +75,6 @@ Global
 		{8B0A6566-6722-4550-8EF2-1D91DF188F9B} = {3F47B841-9074-4317-8ACA-0F2EEA34FA62}
 		{D8B93026-36CE-4CBB-8260-7821239108E2} = {77D1B95E-D2FD-4C41-9458-3A5DAC7C77E9}
 		{CBF02EBF-EB36-42AA-8557-B95CEF5FD175} = {3F47B841-9074-4317-8ACA-0F2EEA34FA62}
+		{5C81C1DB-EE29-41B7-8AC8-7730C03FEB06} = {77D1B95E-D2FD-4C41-9458-3A5DAC7C77E9}
 	EndGlobalSection
 EndGlobal

--- a/src/parquet-utils/ColumnSummaryStats.cs
+++ b/src/parquet-utils/ColumnSummaryStats.cs
@@ -1,0 +1,52 @@
+﻿using System;
+
+namespace Parquet.Data
+{
+   /// <summary>
+   /// General column statistics
+   /// </summary>
+   public class ColumnSummaryStats
+   {
+      /// <summary>
+      /// Initialises a dataset with a column name
+      /// </summary>
+      /// <param name="columnName">A dataset columnname</param>
+      public ColumnSummaryStats(string columnName)
+      {
+         ColumnName = columnName;
+      }
+      /// <summary>
+      /// Contains the column name of the stats class
+      /// </summary>
+      public string ColumnName { get; set; }
+
+      /// <summary>
+      /// Number of null values
+      /// </summary>
+      public int NullCount;
+      /// <summary>
+      /// The max value for the column
+      /// </summary>
+      public double Max;
+      /// <summary>
+      /// The min value for the column
+      /// </summary>
+      public double Min;
+      /// <summary>
+      /// The mean value for the column
+      /// </summary>
+      public double Mean;
+      /// <summary>
+      /// The column standard deviation 
+      /// </summary>
+      public double StandardDeviation;
+
+      /// <summary>Returns a string that represents the current object.</summary>
+      /// <returns>A string that represents the current object.</returns>
+      public override string ToString()
+      {
+         return
+            $"ColumnName: {ColumnName}\nNullCount: {NullCount}\nMax: {Max}\nMin: {Min}\nMean: {Mean}\nStandard Deviation: {StandardDeviation}";
+      }
+   }
+}

--- a/src/parquet-utils/DataSetSummaryStats.cs
+++ b/src/parquet-utils/DataSetSummaryStats.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using Parquet.Data;
+using Parquet.Data.Stats;
+
+namespace Parquet.Data
+{
+   public class DataSetSummaryStats
+   {
+      private readonly Parquet.Data.DataSet _ds;
+      private readonly Dictionary<StatsHandler, Type[]> _handlers = new Dictionary<StatsHandler, Type[]>();
+
+      public DataSetSummaryStats(DataSet ds)
+      {
+         _ds = ds;
+         _handlers.Add(new MaxStatsHandler(), NumericTypes);
+         _handlers.Add(new NullStatsHandler(), AllTypes);
+         _handlers.Add(new MinStatsHandler(), NumericTypes);
+         _handlers.Add(new MeanStatsHandler(), NumericTypes);
+         _handlers.Add(new StdDevHandler(), NumericTypes);
+      }
+
+      private Type[] NumericTypes => new Type[] {typeof(double), typeof(int), typeof(float), typeof(long)};
+      private Type[] AllTypes => new Type[] { typeof(double), typeof(int), typeof(float), typeof(long), typeof(string), typeof(DateTimeOffset) };
+
+      public ColumnSummaryStats GetColumnStats(int index)
+      {
+         var stats = new ColumnSummaryStats(_ds.Schema.ColumnNames[index]);
+         var columns = _ds.GetColumn(index);
+         
+         foreach (var handler in _handlers)
+         {
+            // This should be responsible for it's own types
+            handler.Key.GetColumnStats(new ColumnStatsDetails(columns, stats, handler.Value, _ds.Schema.Elements[index].ElementType));
+         }
+
+         return stats;
+      }
+
+      public ColumnSummaryStats GetColumnStats(SchemaElement schema)
+      {
+         int index = _ds.Schema.GetElementIndex(schema);
+         return GetColumnStats(index);
+      }
+
+   }
+}

--- a/src/parquet-utils/Stats/ColumnStatsDetails.cs
+++ b/src/parquet-utils/Stats/ColumnStatsDetails.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections;
+
+namespace Parquet.Data.Stats
+{
+   /// <summary>
+   /// Contains the details for each of the coolumns where stats are calculated
+   /// </summary>
+   public struct ColumnStatsDetails
+   {
+      /// <summary>
+      /// Used to construct a ColumnStartDetails
+      /// </summary>
+      public ColumnStatsDetails(IList values, ColumnSummaryStats columnSummaryStats, System.Type[] acceptedTypes,
+         System.Type columnType)
+      {
+         Values = values;
+         ColumnSummaryStats = columnSummaryStats;
+         AcceptedTypes = acceptedTypes;
+         ColumnType = columnType;
+      }
+      /// <summary>
+      /// The stats values
+      /// </summary>
+      public IList Values;
+      /// <summary>
+      /// The type to hold the values
+      /// </summary>
+      public ColumnSummaryStats ColumnSummaryStats;
+      /// <summary>
+      /// The types that can be used to calculate the value
+      /// </summary>
+      public System.Type[] AcceptedTypes;
+      /// <summary>
+      /// The type of column for the schema 
+      /// </summary>
+      public System.Type ColumnType;
+   }
+}

--- a/src/parquet-utils/Stats/MaxStatsHandler.cs
+++ b/src/parquet-utils/Stats/MaxStatsHandler.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections;
+using System.Linq;
+
+namespace Parquet.Data.Stats
+{
+   /// <summary>
+   /// Used to return the min value of the column
+   /// </summary>
+   public class MaxStatsHandler : StatsHandler
+   {
+      /// <summary>
+      /// Gets the count of null values given the list of column values
+      /// </summary>
+      /// <param name="values">A list of values</param>
+      /// <returns>A count of null values</returns>
+      public override ColumnSummaryStats GetColumnStats(ColumnStatsDetails values)
+      {
+         if (!CanCalculateWithType(values))
+            return values.ColumnSummaryStats;
+         double max = Convert.ToDouble(values.Values.Cast<object>().Max());
+         values.ColumnSummaryStats.Max = max;
+         return values.ColumnSummaryStats;
+      }
+
+   }
+}

--- a/src/parquet-utils/Stats/MeanStatsHandler.cs
+++ b/src/parquet-utils/Stats/MeanStatsHandler.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections;
+using System.Linq;
+
+namespace Parquet.Data.Stats
+{
+   /// <summary>
+   /// Used to return the min value of the column
+   /// </summary>
+   public class MeanStatsHandler : StatsHandler
+   {
+      /// <summary>
+      /// Gets the count of null values given the list of column values
+      /// </summary>
+      /// <param name="values">A list of values</param>
+      /// <returns>A count of null values</returns>
+      public override ColumnSummaryStats GetColumnStats(ColumnStatsDetails values)
+      {
+         if (!CanCalculateWithType(values))
+            return values.ColumnSummaryStats;
+         double count = values.Values.Count;
+         double sum = values.Values.Cast<object>().Sum(value => Convert.ToDouble(value));
+         values.ColumnSummaryStats.Mean = sum / count;
+         return values.ColumnSummaryStats;
+      }
+   }
+}

--- a/src/parquet-utils/Stats/MinStatsHandler.cs
+++ b/src/parquet-utils/Stats/MinStatsHandler.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections;
+using System.Linq;
+
+namespace Parquet.Data.Stats
+{
+   /// <summary>
+   /// Used to return the min value of the column
+   /// </summary>
+   public class MinStatsHandler : StatsHandler
+   {
+      /// <summary>
+      /// Gets the count of null values given the list of column values
+      /// </summary>
+      /// <param name="values">A list of values</param>
+      /// <returns>A count of null values</returns>
+      public override ColumnSummaryStats GetColumnStats(ColumnStatsDetails values)
+      {
+         if (!CanCalculateWithType(values))
+            return values.ColumnSummaryStats;
+         double min = Convert.ToDouble(values.Values.Cast<object>().Min());
+         values.ColumnSummaryStats.Min = min;
+         return values.ColumnSummaryStats;
+      }
+   }
+}

--- a/src/parquet-utils/Stats/NullStatsHandler.cs
+++ b/src/parquet-utils/Stats/NullStatsHandler.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using System.Linq;
+
+namespace Parquet.Data.Stats
+{
+   /// <summary>
+   /// Used to return the number of null values in the column
+   /// </summary>
+   public class NullStatsHandler : StatsHandler
+   {
+      /// <summary>
+      /// Gets the count of null values given the list of column values
+      /// </summary>
+      /// <param name="values">A list of values</param>
+      /// <returns>A count of null values</returns>
+      public override ColumnSummaryStats GetColumnStats(ColumnStatsDetails values)
+      {
+         if (!CanCalculateWithType(values))
+            return values.ColumnSummaryStats;
+         int totalNulls = values.Values.Cast<object>().Count(value => value == null);
+         values.ColumnSummaryStats.NullCount = totalNulls;
+         return values.ColumnSummaryStats;
+      }
+   }
+}

--- a/src/parquet-utils/Stats/StatsHandler.cs
+++ b/src/parquet-utils/Stats/StatsHandler.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Parquet.Thrift;
+
+namespace Parquet.Data.Stats
+{
+   /// <summary>
+   /// Handles all requests to get stats for the column
+   /// </summary>
+    public abstract class StatsHandler
+    {
+      /// <summary>
+      /// Gets the stats for each column
+      /// </summary>
+      /// <param name="values">The values for each column</param>
+      /// <returns>A columnstats type</returns>
+       public abstract ColumnSummaryStats GetColumnStats(ColumnStatsDetails values);
+
+      /// <summary>
+      /// Determines whether this can be used with the apparent schema type
+      /// </summary>
+      /// <param name="values">The structure containing the values</param>
+      /// <returns>A boolean value as to whether it can be calculated or not</returns>
+      public bool CanCalculateWithType(ColumnStatsDetails values)
+      {
+         return values.AcceptedTypes.Contains(values.ColumnType);
+      }
+   }
+}

--- a/src/parquet-utils/Stats/StdDevHandler.cs
+++ b/src/parquet-utils/Stats/StdDevHandler.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections;
+using System.Linq;
+
+namespace Parquet.Data.Stats
+{
+   /// <summary>
+   /// Used to return the min value of the column
+   /// </summary>
+   public class StdDevHandler : StatsHandler
+   {
+      /// <summary>
+      /// Gets the count of null values given the list of column values
+      /// </summary>
+      /// <param name="values">A list of values</param>
+      /// <returns>A count of null values</returns>
+      public override ColumnSummaryStats GetColumnStats(ColumnStatsDetails values)
+      {
+         if (!CanCalculateWithType(values))
+            return values.ColumnSummaryStats;
+         double count = values.Values.Count;
+         double sum = values.Values.Cast<object>().Sum(value => Convert.ToDouble(value));
+         double average = sum / count;
+         double varianceSum = values.Values.Cast<object>().Sum(item => Math.Pow(Convert.ToDouble(item) - average, 2));
+         values.ColumnSummaryStats.StandardDeviation = Math.Sqrt(varianceSum / (count - 1));
+         return values.ColumnSummaryStats;
+      }
+   }
+}

--- a/src/parquet-utils/parquet-utils.csproj
+++ b/src/parquet-utils/parquet-utils.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.4</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Parquet\Parquet.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
### Fixes

Issue #134 

### Description

moved to a library parquet-utils to give dataframe capabilities for summary nulls, sd, quantiles etc.

### Todos
- [ ] unit/integration tests
- [ ] documentation
