### PR TITLE
183 impala test files

### DIFF
--- a/3rdparty/fastparquet/.vscode/launch.json
+++ b/3rdparty/fastparquet/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python",
+            "type": "python",
+            "request": "launch",
+            "stopOnEntry": "false",
+            "pythonPath": "${config:python.pythonPath}",
+            "program": "${file}",
+            "cwd": "${workspaceRoot}",
+            "env": {},
+            "envFile": "${workspaceRoot}/.env",
+            "debugOptions": [
+                "WaitOnAbnormalExit",
+                "WaitOnNormalExit",
+                "RedirectOutput"
+            ]
+        }
+    ]
+}

--- a/3rdparty/fastparquet/run.py
+++ b/3rdparty/fastparquet/run.py
@@ -1,0 +1,7 @@
+from fastparquet import ParquetFile
+
+pf = ParquetFile("C:\dev\parquet-dotnet\src\Parquet.Test\data\customer.impala.parquet")
+
+df = pf.to_pandas()
+
+#print(df)

--- a/src/Parquet.Test/ParquetReaderTest.cs
+++ b/src/Parquet.Test/ParquetReaderTest.cs
@@ -147,6 +147,11 @@ namespace Parquet.Test
       [Fact]
       public void Reads_compat_customer_impala_file()
       {
+         /*
+          * c_name:
+          *    45 pages (0-44)
+          */
+
          DataSet customer = ParquetReader.ReadFile(GetDataFilePath("customer.impala.parquet"));
       }
 

--- a/src/Parquet.Test/ParquetReaderTest.cs
+++ b/src/Parquet.Test/ParquetReaderTest.cs
@@ -4,6 +4,7 @@ using Parquet.Data;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Text;
 using Xunit;
 
@@ -136,6 +137,26 @@ namespace Parquet.Test
          DataSet ds1 = ParquetReader.Read(ms);
          Assert.True(ds1.Metadata.CreatedBy.StartsWith("parquet-dotnet"));
       }
+
+      [Fact]
+      public void Reads_compat_nation_impala_file()
+      {
+         DataSet nation = ParquetReader.ReadFile(GetDataFilePath("nation.impala.parquet"));
+      }
+
+      [Fact]
+      public void Reads_compat_customer_impala_file()
+      {
+         DataSet customer = ParquetReader.ReadFile(GetDataFilePath("customer.impala.parquet"));
+      }
+
+
+      private string GetDataFilePath(string name)
+      {
+         string thisPath = Assembly.Load(new AssemblyName("Parquet.Test")).Location;
+         return Path.Combine(Path.GetDirectoryName(thisPath), "data", name);
+      }
+
 
       class ReadableNonSeekableStream : DelegatedStream
       {

--- a/src/Parquet.Test/ParquetReaderTest.cs
+++ b/src/Parquet.Test/ParquetReaderTest.cs
@@ -138,12 +138,16 @@ namespace Parquet.Test
          Assert.True(ds1.Metadata.CreatedBy.StartsWith("parquet-dotnet"));
       }
 
+      //this only tests that the file is readable as it used to completely crash before
       [Fact]
       public void Reads_compat_nation_impala_file()
       {
          DataSet nation = ParquetReader.ReadFile(GetDataFilePath("nation.impala.parquet"));
+
+         Assert.Equal(25, nation.RowCount);
       }
 
+      //this only tests that the file is readable as it used to completely crash before
       [Fact]
       public void Reads_compat_customer_impala_file()
       {
@@ -153,6 +157,8 @@ namespace Parquet.Test
           */
 
          DataSet customer = ParquetReader.ReadFile(GetDataFilePath("customer.impala.parquet"));
+
+         Assert.Equal(150000, customer.RowCount);
       }
 
 

--- a/src/Parquet/Data/Schema.cs
+++ b/src/Parquet/Data/Schema.cs
@@ -59,10 +59,27 @@ namespace Parquet.Data
       /// Get schema element by index
       /// </summary>
       /// <param name="i">Index of schema element</param>
-      /// <returns></returns>
+      /// <returns>Schema element</returns>
       public SchemaElement this[int i]
       {
          get { return _elements[i]; }
+      }
+
+      /// <summary>
+      /// Get schema element by name
+      /// </summary>
+      /// <param name="name">Schema element name</param>
+      /// <returns>Schema element</returns>
+      public SchemaElement this[string name]
+      {
+         get
+         {
+            SchemaElement result = _elements.FirstOrDefault(e => e.Name == name);
+
+            if (result == null) throw new ArgumentException($"schema element '{name}' not found", nameof(name));
+
+            return result;
+         }
       }
 
       /// <summary>

--- a/src/Parquet/File/PColumn.cs
+++ b/src/Parquet/File/PColumn.cs
@@ -100,7 +100,9 @@ namespace Parquet.File
                break;   //limit reached
             }
 
-            ph = _thrift.Read<Thrift.PageHeader>(); //get next page
+            ph = ReadDataPageHeader(dataPageCount); //get next page
+
+
             if (ph.Type != Thrift.PageType.DATA_PAGE)
             {
                break;
@@ -112,6 +114,18 @@ namespace Parquet.File
          ValueMerger.Trim(mergedValues, (int)offset, (int)count);
 
          return mergedValues;
+      }
+
+      private Thrift.PageHeader ReadDataPageHeader(int pageNo)
+      {
+         try
+         {
+            return _thrift.Read<Thrift.PageHeader>();
+         }
+         catch (Exception ex)
+         {
+            throw new IOException($"failed to read data page header after page #{pageNo}", ex);
+         }
       }
 
       private IList ReadDictionaryPage(Thrift.PageHeader ph)

--- a/src/Parquet/File/ValueMerger.cs
+++ b/src/Parquet/File/ValueMerger.cs
@@ -25,7 +25,7 @@ namespace Parquet.File
       /// <summary>
       /// Applies dictionary with indexes and definition levels directly over the column
       /// </summary>
-      public IList Apply(IList dictionary, List<int> definitions, List<int> indexes, long maxValues)
+      public IList Apply(IList dictionary, List<int> definitions, List<int> indexes, int maxValues)
       {
          if (dictionary == null && definitions == null && indexes == null) return _values;  //values are just values
 
@@ -36,7 +36,7 @@ namespace Parquet.File
          return _values;
       }
 
-      private void ApplyDictionary(IList dictionary, List<int> indexes, long maxValues)
+      private void ApplyDictionary(IList dictionary, List<int> indexes, int maxValues)
       {
          //merge with dictionary if present
          if (dictionary == null) return;
@@ -54,7 +54,7 @@ namespace Parquet.File
          foreach (var el in values) _values.Add(el);
       }
 
-      private void ApplyDefinitions(List<int> definitions, long maxValues)
+      private void ApplyDefinitions(List<int> definitions, int maxValues)
       {
          if (definitions == null) return;
 
@@ -81,16 +81,16 @@ namespace Parquet.File
          _values = values;
       }
 
-      public static void TrimTail(IList list, long maxValues)
+      public static void TrimTail(IList list, int maxValues)
       {
          if (list.Count > maxValues)
          {
-            int diffCount = list.Count - (int)maxValues;
+            int diffCount = list.Count - maxValues;
             while (--diffCount >= 0) list.RemoveAt(list.Count - 1); //more effective than copying the list again
          }
       }
 
-      public static void TrimHead(IList list, long maxValues)
+      public static void TrimHead(IList list, int maxValues)
       {
          while(list.Count > maxValues)
          {
@@ -98,7 +98,7 @@ namespace Parquet.File
          }
       }
 
-      public static void Trim(IList list, long offset, long count)
+      public static void Trim(IList list, int offset, int count)
       {
          TrimHead(list, list.Count - offset);
          TrimTail(list, count);

--- a/src/Parquet/File/Values/RunLengthBitPackingHybridValuesReader.cs
+++ b/src/Parquet/File/Values/RunLengthBitPackingHybridValuesReader.cs
@@ -38,7 +38,6 @@ namespace Parquet.File.Values
          if (length == 0) length = reader.ReadInt32();
 
          long start = reader.BaseStream.Position;
-         int pagesNo = 0;
          while (reader.BaseStream.Position - start < length)
          {
             int header = ReadUnsignedVarInt(reader);
@@ -52,8 +51,6 @@ namespace Parquet.File.Values
             {
                ReadBitpacked(header, reader, bitWidth, destination);
             }
-
-            pagesNo++;
          }
       }
 

--- a/src/Parquet/File/Values/RunLengthBitPackingHybridValuesReader.cs
+++ b/src/Parquet/File/Values/RunLengthBitPackingHybridValuesReader.cs
@@ -38,6 +38,7 @@ namespace Parquet.File.Values
          if (length == 0) length = reader.ReadInt32();
 
          long start = reader.BaseStream.Position;
+         int pagesNo = 0;
          while (reader.BaseStream.Position - start < length)
          {
             int header = ReadUnsignedVarInt(reader);
@@ -51,6 +52,8 @@ namespace Parquet.File.Values
             {
                ReadBitpacked(header, reader, bitWidth, destination);
             }
+
+            pagesNo++;
          }
       }
 
@@ -76,8 +79,11 @@ namespace Parquet.File.Values
          int groupCount = header >> 1;
          int count = groupCount * 8;
          int byteCount = (bitWidth * count) / 8;
+         //int byteCount2 = (int)Math.Ceiling(bitWidth * count / 8.0);
 
          byte[] rawBytes = reader.ReadBytes(byteCount);
+         byteCount = rawBytes.Length;  //sometimes there will be less data available, typically on the last page
+
          int mask = MaskForBits(bitWidth);
 
          int i = 0;


### PR DESCRIPTION
### Fixes

Issue #183 

### Description

A few issues found during impala test files investigation:
- in bitpacked encoding sometimes number of bytes read will be smaller than requested, usually on the last data page
- number of rows read in the column wasn't determinted properly

### Todos
- [x] unit/integration tests
- [x] documentation
