### PR TITLE
Fix appending to DataSets containing a MapField column

### DIFF
--- a/src/Parquet.Test/ParquetWriterTest.cs
+++ b/src/Parquet.Test/ParquetWriterTest.cs
@@ -165,18 +165,19 @@ namespace Parquet.Test
             new DataField<byte>("Flag"),
             new DataField<sbyte>("Flag2"),
             new DataField<short>("Flag3"),
-            new DataField<ushort>("Flag4"));
+            new DataField<ushort>("Flag4"),
+            new MapField("MapData", new DataField<string>("Key"),  new DataField<string>("Value")));
 
          var ds1 = new DataSet(schema);
-
-         ds1.Add(1, DateTime.Now, DateTimeOffset.Now, "Record1", System.Text.Encoding.ASCII.GetBytes("SomeData"), false, 123.4f, 200M, 100000L, 1331313D, (byte)1, (sbyte)-1, (short)-500, (ushort)500);
-         ds1.Add(1, DateTime.Now, DateTimeOffset.Now, "Record2", System.Text.Encoding.ASCII.GetBytes("SomeData2"), false, 124.4f, 300M, 200000L, 2331313D, (byte)2, (sbyte)-2, (short)-400, (ushort)400);
+         var dict = new Dictionary<string, string> { { "foo", "bar" } };
+         ds1.Add(1, DateTime.Now, DateTimeOffset.Now, "Record1", System.Text.Encoding.ASCII.GetBytes("SomeData"), false, 123.4f, 200M, 100000L, 1331313D, (byte)1, (sbyte)-1, (short)-500, (ushort)500, dict);
+         ds1.Add(1, DateTime.Now, DateTimeOffset.Now, "Record2", System.Text.Encoding.ASCII.GetBytes("SomeData2"), false, 124.4f, 300M, 200000L, 2331313D, (byte)2, (sbyte)-2, (short)-400, (ushort)400, dict);
 
          ParquetWriter.Write(ds1, ms, CompressionMethod.Snappy, null, null, false);
 
          var ds2 = new DataSet(schema);
-         ds2.Add(1, DateTime.Now, DateTimeOffset.Now, "Record3", System.Text.Encoding.ASCII.GetBytes("SomeData3"), false, 125.4f, 400M, 300000L, 3331313D, (byte)3, (sbyte)-3, (short)-600, (ushort)600);
-         ds2.Add(1, DateTime.Now, DateTimeOffset.Now, "Record4", System.Text.Encoding.ASCII.GetBytes("SomeData4"), false, 126.4f, 500M, 400000L, 4331313D, (byte)4, (sbyte)-4, (short)-700, (ushort)700);
+         ds2.Add(1, DateTime.Now, DateTimeOffset.Now, "Record3", System.Text.Encoding.ASCII.GetBytes("SomeData3"), false, 125.4f, 400M, 300000L, 3331313D, (byte)3, (sbyte)-3, (short)-600, (ushort)600, dict);
+         ds2.Add(1, DateTime.Now, DateTimeOffset.Now, "Record4", System.Text.Encoding.ASCII.GetBytes("SomeData4"), false, 126.4f, 500M, 400000L, 4331313D, (byte)4, (sbyte)-4, (short)-700, (ushort)700, dict);
 
          ParquetWriter.Write(ds2, ms, CompressionMethod.Snappy, null, null, true);
       }

--- a/src/Parquet.Test/SchemaTest.cs
+++ b/src/Parquet.Test/SchemaTest.cs
@@ -101,6 +101,22 @@ namespace Parquet.Test
       }
 
       [Fact]
+      public void Map_fields_with_same_types_are_equal()
+      {
+         Assert.Equal(new MapField("dictionary", new DataField("key", DataType.Int32), new DataField("value", DataType.String)),
+                      new MapField("dictionary", new DataField("key", DataType.Int32), new DataField("value", DataType.String)));
+
+      }
+
+      [Fact]
+      public void Map_fields_with_different_types_are_unequal()
+      {
+         Assert.NotEqual(new MapField("dictionary", new DataField("key", DataType.String), new DataField("value", DataType.String)),
+                      new MapField("dictionary", new DataField("key", DataType.Int32), new DataField("value", DataType.String)));
+
+      }
+
+      [Fact]
       public void Byte_array_schema_is_a_bytearray_type()
       {
          var field = new DataField<byte[]>("bytes");

--- a/src/Parquet/Data/Schema/MapField.cs
+++ b/src/Parquet/Data/Schema/MapField.cs
@@ -91,5 +91,12 @@ namespace Parquet.Data
          keys.Add(keysList);
          values.Add(valuesList);
       }
+
+      public override bool Equals(Object obj)
+      {
+         MapField other = (MapField)obj;
+         return Name.Equals(other.Name) && KeyType.Equals(other.KeyType) && ValueType.Equals(other.ValueType);
+      }
+   
    }
 }


### PR DESCRIPTION
### Fixes

Issue #284 

### Description

Equality checking for MapFields fell back to the default Object equality
checker, causing a mismatch between the schemas of any datasets that
contained a MapField. Added equality checking to MapFields.


- [X] I have included unit tests validating this fix.
- [X] I have updated markdown documentation where required.
