### PR TITLE
Support .NET 4.5 and up (Issue #294)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/w3o50mweytm85uxb?svg=true)](https://ci.appveyor.com/project/aloneguid/parquet-dotnet)
 
 **Fully managed** .NET library to read and write [Apache Parquet](https://parquet.apache.org/) files. Supports:
-- `.NET 4.5.1` and up.
+- `.NET 4.5` and up.
 - `.NET Standard 1.4` and up.
 
 Runs on all flavors of Windows, Linux, and mobile devices (iOS, Android) via [Xamarin](https://www.xamarin.com/)

--- a/src/Parquet.Json/Parquet.Json.csproj
+++ b/src/Parquet.Json/Parquet.Json.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.4;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard1.4;net45</TargetFrameworks>
     <Version>1.2.0.0</Version>
     <FileVersion>1.2.3.4</FileVersion>
     <AssemblyVersion>1.2.0.0</AssemblyVersion>

--- a/src/Parquet.Test/Parquet.Test.csproj
+++ b/src/Parquet.Test/Parquet.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net45</TargetFrameworks>
     <SignAssembly>true</SignAssembly>    
     <AssemblyOriginatorKeyFile>..\pqnet.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Parquet/Parquet.csproj
+++ b/src/Parquet/Parquet.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.4;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard1.4;net45</TargetFrameworks>
     <Version>1.2.0.0</Version>
     <FileVersion>1.2.3.4</FileVersion>
     <AssemblyVersion>1.2.0.0</AssemblyVersion>
@@ -9,7 +9,7 @@
     <AssemblyOriginatorKeyFile>..\pqnet.snk</AssemblyOriginatorKeyFile>
     <Description>.NET library to read and write Apache Parquet files.
 Supports all parquet features, including maps, structs, lists, repeatable fields.
-Compatible with .NET 4.5.1 and .NET Standard 1.4 and up.
+Compatible with .NET 4.5 and .NET Standard 1.4 and up.
 Works on all flavours of Windows and Linux. Compatible with iOS and Android via Xamarin.</Description>
     <Authors>Ivan Gavryliuk (@aloneguid); Richard Conway (@azurecoder)</Authors>
     <Company>Elastacloud</Company>
@@ -35,10 +35,10 @@ Works on all flavours of Windows and Linux. Compatible with iOS and Android via 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard1.4|AnyCPU'">
     <DocumentationFile>bin\Release\netstandard1.4\Parquet.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net451|AnyCPU'">
-    <DocumentationFile>bin\Debug\net451\Parquet.xml</DocumentationFile>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net45|AnyCPU'">
+    <DocumentationFile>bin\Debug\net45\Parquet.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net451|AnyCPU'">
-    <DocumentationFile>bin\Release\net451\Parquet.xml</DocumentationFile>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net45|AnyCPU'">
+    <DocumentationFile>bin\Release\net45\Parquet.xml</DocumentationFile>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
### Fixes
Issue #294 

### Description
Parquet.Net  support for .NET 4.5 and up. This will allow it to be used by projects targeting.Net 4.5

-  I have updated markdown documentation where required.
