### PR TITLE
Upgrade visibility for certain fields to display parquet columns

### DIFF
--- a/src/Parquet.Test/PrimitiveTypesTest.cs
+++ b/src/Parquet.Test/PrimitiveTypesTest.cs
@@ -42,7 +42,7 @@ namespace Parquet.Test
          ds.Add(1000, new Interval(1,2,3));
 
          DataSet ds1 = DataSetGenerator.WriteRead(ds);
-         Interval retInterval = (Interval)ds1[0][1];
+         var retInterval = (Interval)ds1[0][1];
          Assert.Equal(1, retInterval.Months);
          Assert.Equal(2, retInterval.Days);
          Assert.Equal(3, retInterval.Millis);

--- a/src/Parquet.Test/PrimitiveTypesTest.cs
+++ b/src/Parquet.Test/PrimitiveTypesTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using Parquet.Data;
+using Parquet.File.Values.Primitives;
 using Xunit;
 
 namespace Parquet.Test
@@ -30,6 +31,21 @@ namespace Parquet.Test
             Assert.True(ds1[i].GetBoolean(1), $"got FALSE at position {i}");
          }
 
+      }
+
+      [Fact]
+      public void Interval_tests()
+      {
+         var ds = new DataSet(
+            new DataField<int>("id"),
+            new DataField<Interval>("interval"));
+         ds.Add(1000, new Interval(1,2,3));
+
+         DataSet ds1 = DataSetGenerator.WriteRead(ds);
+         Interval retInterval = (Interval)ds1[0][1];
+         Assert.Equal(1, retInterval.Months);
+         Assert.Equal(2, retInterval.Days);
+         Assert.Equal(3, retInterval.Millis);
       }
    }
 }

--- a/src/Parquet/Data/Schema/Field.cs
+++ b/src/Parquet/Data/Schema/Field.cs
@@ -19,9 +19,9 @@ namespace Parquet.Data
       public string Name { get; private set; }
 
       /// <summary>
-      /// Only used internally!
+      /// Path
       /// </summary>
-      internal string Path { get; set; }
+      public string Path { get; set; }
 
       internal virtual string PathPrefix { set { } }
 

--- a/src/Parquet/Data/Schema/Field.cs
+++ b/src/Parquet/Data/Schema/Field.cs
@@ -21,7 +21,7 @@ namespace Parquet.Data
       /// <summary>
       /// Path
       /// </summary>
-      public string Path { get; set; }
+      public string Path { get; internal set; }
 
       internal virtual string PathPrefix { set { } }
 

--- a/src/Parquet/Data/Schema/MapField.cs
+++ b/src/Parquet/Data/Schema/MapField.cs
@@ -11,9 +11,9 @@ namespace Parquet.Data
    {
       internal const string ContainerName = "key_value";
 
-      internal DataField Key { get; private set; }
+      public DataField Key { get; private set; }
 
-      internal DataField Value { get; private set; }
+      public DataField Value { get; private set; }
 
       public DataType KeyType => Key.DataType;
 

--- a/src/Parquet/File/Values/Primitives/Interval.cs
+++ b/src/Parquet/File/Values/Primitives/Interval.cs
@@ -4,7 +4,7 @@ namespace Parquet.File.Values.Primitives
    /// A parquet interval type compatible with a Spark INTERVAL type
    /// 12 byte little Endian structure fits in an INT96 original type with an INTERVAL converted type
    /// </summary>
-   struct Interval
+   public struct Interval
    {
       /// <summary>
       /// Used to create an interval type


### PR DESCRIPTION
### Fixes

Issue #296 

### Description
Public Path, Key, and Value would be used to specify the origins of a column. We would like to be able to distinguish elements of multilevel Structs, Lists and Maps (Lists of Maps, Lists of Structs containing strings and Maps, a string that belongs to a Struct, etc.) by examining the Path. This is used to name flattened columns to make the structure readable and obvious when printed out as text, for example when we want to examine the contents of a Parquet file as a csv.

Public Interval enables us to retrieve a primitive Interval field and access the values contained in it, like how we would with other primitive data types such as a bool corresponding to DataType.Boolean.