### PR TITLE
Fixed an issue where Field columns were not always loaded correctly.

### DIFF
--- a/src/Parquet/Data/RowExtractor.cs
+++ b/src/Parquet/Data/RowExtractor.cs
@@ -59,6 +59,9 @@ namespace Parquet.Data
                throw new ParquetException($"something terrible happened, there is no column by name '{field.Name}' and path '{field.Path}'");
             }
 
+	         if (values.Count <= index)
+		         return null;
+
             return values[index];
          }
       }
@@ -70,7 +73,7 @@ namespace Parquet.Data
       {
          var elementColumns = new Dictionary<string, IList>();
 
-         count = int.MaxValue;
+         count = 0;
 
          foreach (Field field in fields)
          {
@@ -81,21 +84,21 @@ namespace Parquet.Data
                case SchemaType.Data:
                   IList value = columns[key][index] as IList;
                   elementColumns[key] = value;
-                  if (value.Count < count) count = value.Count;
+	               count = Math.Max(count, value.Count);
                   break;
 
                case SchemaType.List:
                   var listField = (ListField)field;
                   Dictionary<string, IList> listColumns = CreateFieldColumns(new[] { listField.Item }, index, columns, out int listCount);
                   elementColumns.AddRange(listColumns);
-                  count = Math.Min(count, listColumns.Min(kvp => kvp.Value.Count));
+                  count = Math.Max(count, listColumns.Min(kvp => kvp.Value.Count));
                   break;
 
                case SchemaType.Struct:
                   var structField = (StructField)field;
                   Dictionary<string, IList> structColumns = CreateFieldColumns(structField.Fields, index, columns, out int structCount);
                   elementColumns.AddRange(structColumns);
-                  count = Math.Min(count, structColumns.Min(kvp => kvp.Value.Count));
+                  count = Math.Max(count, structColumns.Min(kvp => kvp.Value.Count));
                   break;
 
                default:


### PR DESCRIPTION
This change fixes an issue where not all data is loaded into the dataset when the schema structure contained null values.

Issue #

Data was not always being loaded into the dataset correct. When the schema contains a structure and the first field has a value the count was being set correctly. However, when looping through the rest of the fields and none of the remaining fields have a value the count was being reset to 0. Then when the method returned no rows were being added even though there was valid data that should be added. 


desctiption goes here

- [ ] I have included unit tests validating this fix.
- [ ] I have updated markdown documentation where required.

<!--
 I UNDERSTAND THAT NO TESTS AND NO DOCUMENTATION WILL FAIL MY PULL REQUEST
-->
