### PR TITLE
Write performance improvements

### DIFF
--- a/src/Parquet/Data/BasicDataTypeHandler.cs
+++ b/src/Parquet/Data/BasicDataTypeHandler.cs
@@ -70,7 +70,9 @@ namespace Parquet.Data
 
       public virtual void Write(Thrift.SchemaElement tse, BinaryWriter writer, IList values)
       {
-         foreach(TSystemType one in values)
+         // casing to an array of TSystemType means we avoid Array.GetValue calls, which are slow
+         var typedArray = (TSystemType[]) values;
+         foreach(TSystemType one in typedArray)
          {
             WriteOne(writer, one);
          }

--- a/src/Parquet/Data/BasicDataTypeHandler.cs
+++ b/src/Parquet/Data/BasicDataTypeHandler.cs
@@ -113,6 +113,11 @@ namespace Parquet.Data
 
       public abstract Array UnpackDefinitions(Array src, int[] definitionLevels, int maxDefinitionLevel);
 
+      public TypedArrayWrapper CreateTypedArrayWrapper(Array array)
+      {
+         return TypedArrayWrapper.Create<TSystemType>(array);
+      }
+
       protected T[] UnpackGenericDefinitions<T>(T[] src, int[] definitionLevels, int maxDefinitionLevel)
       {
          T[] result = (T[])GetArray(definitionLevels.Length, false, true);

--- a/src/Parquet/Data/BasicDataTypeHandler.cs
+++ b/src/Parquet/Data/BasicDataTypeHandler.cs
@@ -113,7 +113,7 @@ namespace Parquet.Data
 
       public abstract Array UnpackDefinitions(Array src, int[] definitionLevels, int maxDefinitionLevel);
 
-      public TypedArrayWrapper CreateTypedArrayWrapper(Array array)
+      public virtual TypedArrayWrapper CreateTypedArrayWrapper(Array array, bool isNullable)
       {
          return TypedArrayWrapper.Create<TSystemType>(array);
       }

--- a/src/Parquet/Data/BasicPrimitiveDataTypeHandler.cs
+++ b/src/Parquet/Data/BasicPrimitiveDataTypeHandler.cs
@@ -24,9 +24,11 @@ namespace Parquet.Data
                : ArrayPool<TSystemType?>.Shared.Rent(minCount);
          }
 
-         return isNullable
-            ? Array.CreateInstance(typeof(TSystemType?), minCount)
-            : Array.CreateInstance(typeof(TSystemType), minCount);
+         if (isNullable)
+         {
+            return new TSystemType?[minCount];
+         }
+         return new TSystemType[minCount];
       }
 
       public override void ReturnArray(Array array, bool isNullable)

--- a/src/Parquet/Data/BasicPrimitiveDataTypeHandler.cs
+++ b/src/Parquet/Data/BasicPrimitiveDataTypeHandler.cs
@@ -48,6 +48,15 @@ namespace Parquet.Data
          return UnpackDefinitions((TSystemType[])untypedSource, definitionLevels, maxDefinitionLevel);
       }
 
+      public override TypedArrayWrapper CreateTypedArrayWrapper(Array array, bool isNullable)
+      {
+         if (isNullable)
+         {
+            return TypedArrayWrapper.Create<TSystemType?>(array);
+         }
+         return TypedArrayWrapper.Create<TSystemType>(array);
+      }
+
       private TSystemType?[] UnpackDefinitions(TSystemType[] src, int[] definitionLevels, int maxDefinitionLevel)
       {
          TSystemType?[] result = (TSystemType?[])GetArray(definitionLevels.Length, false, true);

--- a/src/Parquet/Data/Concrete/StringDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/StringDataTypeHandler.cs
@@ -88,8 +88,8 @@ namespace Parquet.Data.Concrete
          else
          {
             //transofrm to byte array first, as we need the length of the byte buffer, not string length
-            byte[] data = Encoding.UTF8.GetBytes(value);
-            writer.Write((int)data.Length);
+            byte[] data = E.GetBytes(value);
+            writer.Write(data.Length);
             writer.Write(data);
          }
       }

--- a/src/Parquet/Data/DataColumn.cs
+++ b/src/Parquet/Data/DataColumn.cs
@@ -84,11 +84,7 @@ namespace Parquet.Data
 
          if (!Field.HasNulls)
          {
-            for(int i = 0; i < Data.Length; i++)
-            {
-               pooledDefinitionLevels[i] = maxDefinitionLevel;
-            }
-
+            SetPooledDefinitionLevels(maxDefinitionLevel, pooledDefinitionLevels);
             return Data;
          }
 
@@ -99,6 +95,13 @@ namespace Parquet.Data
          {
             bool isNull = typedData.GetValue(i) == null;
             if (isNull) nullCount += 1;
+         }
+
+         // if the field definition said there could be nulls, but weren't, don't incur the overhead of new array allocations and item copying
+         if (nullCount == 0)
+         {
+            SetPooledDefinitionLevels(maxDefinitionLevel, pooledDefinitionLevels);
+            return Data;
          }
 
          //pack
@@ -121,6 +124,14 @@ namespace Parquet.Data
             }
          }
          return result;
+      }
+
+      void SetPooledDefinitionLevels(int maxDefinitionLevel, int[] pooledDefinitionLevels)
+      {
+         for (int i = 0; i < Data.Length; i++)
+         {
+            pooledDefinitionLevels[i] = maxDefinitionLevel;
+         }
       }
    }
 }

--- a/src/Parquet/Data/DataColumn.cs
+++ b/src/Parquet/Data/DataColumn.cs
@@ -90,7 +90,9 @@ namespace Parquet.Data
 
          //get count of nulls
          int nullCount = 0;
-         TypedArrayWrapper typedData = _dataTypeHandler.CreateTypedArrayWrapper(Data);
+         bool isNullable = Field.ClrType.IsNullable();
+
+         TypedArrayWrapper typedData = _dataTypeHandler.CreateTypedArrayWrapper(Data, isNullable);
          for(int i = 0; i < Data.Length; i++)
          {
             bool isNull = typedData.GetValue(i) == null;
@@ -105,8 +107,8 @@ namespace Parquet.Data
          }
 
          //pack
-         Array result = _dataTypeHandler.GetArray(Data.Length - nullCount, false, Field.ClrType.IsNullable());
-         TypedArrayWrapper typedResult = _dataTypeHandler.CreateTypedArrayWrapper(result);
+         Array result = _dataTypeHandler.GetArray(Data.Length - nullCount, false, isNullable);
+         TypedArrayWrapper typedResult = _dataTypeHandler.CreateTypedArrayWrapper(result, isNullable);
 
          int ir = 0;
          for(int i = 0; i < Data.Length; i++)

--- a/src/Parquet/Data/DataColumn.cs
+++ b/src/Parquet/Data/DataColumn.cs
@@ -90,7 +90,7 @@ namespace Parquet.Data
 
          //get count of nulls
          int nullCount = 0;
-         bool isNullable = Field.ClrType.IsNullable();
+         bool isNullable = Field.ClrType.IsNullable() || Data.GetType().GetElementType().IsNullable();
 
          TypedArrayWrapper typedData = _dataTypeHandler.CreateTypedArrayWrapper(Data, isNullable);
          for(int i = 0; i < Data.Length; i++)
@@ -107,8 +107,8 @@ namespace Parquet.Data
          }
 
          //pack
-         Array result = _dataTypeHandler.GetArray(Data.Length - nullCount, false, isNullable);
-         TypedArrayWrapper typedResult = _dataTypeHandler.CreateTypedArrayWrapper(result, isNullable);
+         Array result = _dataTypeHandler.GetArray(Data.Length - nullCount, false, false);
+         TypedArrayWrapper typedResult = _dataTypeHandler.CreateTypedArrayWrapper(result, false);
 
          int ir = 0;
          for(int i = 0; i < Data.Length; i++)

--- a/src/Parquet/Data/DataColumn.cs
+++ b/src/Parquet/Data/DataColumn.cs
@@ -94,18 +94,22 @@ namespace Parquet.Data
 
          //get count of nulls
          int nullCount = 0;
+         TypedArrayWrapper typedData = _dataTypeHandler.CreateTypedArrayWrapper(Data);
          for(int i = 0; i < Data.Length; i++)
          {
-            bool isNull = (Data.GetValue(i) == null);
+            bool isNull = typedData.GetValue(i) == null;
             if (isNull) nullCount += 1;
          }
 
          //pack
-         Array result = Array.CreateInstance(Field.ClrType, Data.Length - nullCount);
+         Array result = _dataTypeHandler.GetArray(Data.Length - nullCount, false, Field.ClrType.IsNullable());
+         TypedArrayWrapper typedResult = _dataTypeHandler.CreateTypedArrayWrapper(result);
+
          int ir = 0;
          for(int i = 0; i < Data.Length; i++)
          {
-            object value = Data.GetValue(i);
+            object value = typedData.GetValue(i);
+            
             if(value == null)
             {
                pooledDefinitionLevels[i] = 0;
@@ -113,7 +117,7 @@ namespace Parquet.Data
             else
             {
                pooledDefinitionLevels[i] = maxDefinitionLevel;
-               result.SetValue(value, ir++);
+               typedResult.SetValue(value, ir++);
             }
          }
          return result;

--- a/src/Parquet/Data/IDataTypeHandler.cs
+++ b/src/Parquet/Data/IDataTypeHandler.cs
@@ -36,5 +36,7 @@ namespace Parquet.Data
       Array MergeDictionary(Array dictionary, int[] indexes);
 
       Array UnpackDefinitions(Array src, int[] definitionLevels, int maxDefinitionLevel);
+
+      TypedArrayWrapper CreateTypedArrayWrapper(Array array);
    }
 }

--- a/src/Parquet/Data/IDataTypeHandler.cs
+++ b/src/Parquet/Data/IDataTypeHandler.cs
@@ -37,6 +37,6 @@ namespace Parquet.Data
 
       Array UnpackDefinitions(Array src, int[] definitionLevels, int maxDefinitionLevel);
 
-      TypedArrayWrapper CreateTypedArrayWrapper(Array array);
+      TypedArrayWrapper CreateTypedArrayWrapper(Array array, bool isNullable);
    }
 }

--- a/src/Parquet/Data/NonDataDataTypeHandler.cs
+++ b/src/Parquet/Data/NonDataDataTypeHandler.cs
@@ -57,7 +57,7 @@ namespace Parquet.Data
          throw new NotSupportedException();
       }
 
-      public TypedArrayWrapper CreateTypedArrayWrapper(Array array)
+      public TypedArrayWrapper CreateTypedArrayWrapper(Array array, bool isNullable)
       {
          throw new NotSupportedException();
       }

--- a/src/Parquet/Data/NonDataDataTypeHandler.cs
+++ b/src/Parquet/Data/NonDataDataTypeHandler.cs
@@ -56,5 +56,10 @@ namespace Parquet.Data
       {
          throw new NotSupportedException();
       }
+
+      public TypedArrayWrapper CreateTypedArrayWrapper(Array array)
+      {
+         throw new NotSupportedException();
+      }
    }
 }

--- a/src/Parquet/Data/TypedArrayWrapper.cs
+++ b/src/Parquet/Data/TypedArrayWrapper.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+namespace Parquet.Data
+{
+   abstract class TypedArrayWrapper
+   {
+      public static TypedArrayWrapper Create<TSystemType>(Array array)
+      {
+         return new GenericTypedArrayWrapper<TSystemType>((TSystemType[]) array);
+      }
+
+      public abstract void SetValue(object value, int index);
+      public abstract object GetValue(int index);
+
+      class GenericTypedArrayWrapper<TSystemType> : TypedArrayWrapper
+      {
+         readonly TSystemType[] _typedArray;
+
+         public GenericTypedArrayWrapper(TSystemType[] typedArray)
+         {
+            _typedArray = typedArray;
+         }
+
+         public override void SetValue(object value, int index)
+         {
+            _typedArray[index] = (TSystemType)value;
+         }
+
+         public override object GetValue(int index)
+         {
+            return _typedArray[index];
+         }
+      }
+   }
+}


### PR DESCRIPTION
### Fixes

I'm prototyping a move away from some proprietary file formats to Parquet so we have more interoperability with Spark.  The format is optimised heavily towards our use case, which is lots of duplicated data but with time series data represented as columns, which needs to be pivoted.  I am willing to let some performance go on the write side as it's distributed over many cores.  That being said, a material increase in write performance will increase our customers cost.  The custom format takes 5 seconds to represent 134mb of text as binary and encodes to 22mb.  The same with Parquet took 2 minutes and encoded to 31mb.

I was interested to see if there were any optimisations to had when writing Parquet files.  This PR shows my findings which are mostly optimisations around accessing Arrays.  This reduced the run-time of my test case by 50%.

### Description

Before I invest much more time in adding some benchmark type unit tests I'd be interested to know if this is acceptable?  I'm happy to spend a bit more time to add some benchmarks.

RE the tests.  I broke a bunch, but I'm not sure if I actually found an issue in the tests or not?  TestBase always creates an Array using `field.ClrNullableIfHasNullTypes` so in the case where we're actually dealing with non-nullable ints (for example) the .net type is actually nullable and the cast fails.  Details are in the fixed tests commit and I believe the behaviour is as expected now, although it's hard to tell the intent.

### Profiler results:

Starting point: 
![image](https://user-images.githubusercontent.com/278561/43116672-c6bd553e-8f00-11e8-85f6-60c130d45a8a.png)

```
public virtual void Write(Thrift.SchemaElement tse, BinaryWriter writer, IList values)
{
   // casing to an array of TSystemType means we avoid Array.GetValue calls, which are slow
   var typedArray = (TSystemType[]) values;
   foreach(TSystemType one in typedArray)
   {
      WriteOne(writer, one);
   }
}

```
After: 

![image](https://user-images.githubusercontent.com/278561/43116711-efcfd406-8f00-11e8-9bc2-9ca4231b3dfb.png)

Avoid `Array.GetValue` / `Array.SetValue `– reduced overhead of PackDefinitions:

![image](https://user-images.githubusercontent.com/278561/43116724-006602d6-8f01-11e8-83bb-99e1536783d5.png)

Short circuit cleaning out nulls if there were no nulls in the array:

![image](https://user-images.githubusercontent.com/278561/43116729-070c8010-8f01-11e8-8ce6-f93086210dea.png)

### Next steps

I need Snappy support as GZip is very slow but I note that is broken (e.g. I can't read data I've written with Snappy compression but I can with none / gzip).  I saw there is an open issue, if no one is going to resolve let me know and I'll take a stab at it.

Assuming you're happy with the changes let me know what else you'd like in terms of benchmarking tests.  

I think to get comparable performance to our bespoke format I'm going to need nested data type support OR support for arrays of doubles.  I saw that there is code for supporting repetitions while I was looking through the code for the optimisations.  Does anyone have an example of using this?  I will have a play tomorrow to see where I get to but if anyone has an example that'll save me some time.