### PR TITLE
Fix for issue #318

### DIFF
--- a/src/Parquet.Test/Parquet.Test.csproj
+++ b/src/Parquet.Test/Parquet.Test.csproj
@@ -37,6 +37,7 @@
     <None Remove="data\mapinstruct.parquet" />
     <None Remove="data\map_array.parq" />
     <None Remove="data\mr_times.parq" />
+    <None Remove="data\multi.page.parquet" />
     <None Remove="data\nation.csv" />
     <None Remove="data\nation.dict.parquet" />
     <None Remove="data\nation.impala.parquet" />
@@ -133,6 +134,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="data\mr_times.parq">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Include="data\multi.page.parquet">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="data\nation.csv">

--- a/src/Parquet/File/DataColumnReader.cs
+++ b/src/Parquet/File/DataColumnReader.cs
@@ -91,7 +91,7 @@ namespace Parquet.File
 
             int totalCount = Math.Max(
                (colData.values == null ? 0 : colData.values.Length) +
-               (colData.indexes == null ? 0 : colData.indexes.Length),
+               (colData.indexes == null ? 0 : colData.indexesOffset),
                (colData.definitions == null ? 0 : colData.definitions.Length));
             if (totalCount >= maxValues) break; //limit reached
 

--- a/src/Parquet/File/DataColumnReader.cs
+++ b/src/Parquet/File/DataColumnReader.cs
@@ -84,7 +84,7 @@ namespace Parquet.File
 
          while (true)
          {
-            int valuesSoFar = Math.Max(colData.indexes == null ? 0 : colData.indexes.Length, colData.values == null ? 0 : colData.values.Length);
+            int valuesSoFar = Math.Max(colData.indexes == null ? 0 : colData.indexesOffset, colData.values == null ? 0 : colData.values.Length);
             ReadDataPage(ph, colData, maxValues - valuesSoFar);
 
             pagesRead++;


### PR DESCRIPTION
### Fixes

Issue #318 

### Description

Note: the fix I have put in place could obviously do with a review as I am not entirely up to speed with the parquet file format. 

The approach I have taken is to use the indexesOffset rather than the indexesLength as the indexesLength array will always be the number of rows due to how the array is created in ReadColumn().

There is possibly a similar issue on [line 87](https://github.com/Confusedfish/parquet-dotnet/blob/4ebf0ae3b164796606243c330923709f67ba0687/src/Parquet/File/DataColumnReader.cs#L87) but since the test passes without modifying that I have not changed it.

- [X] I have included unit tests validating this fix.
- [NA] I have updated markdown documentation where required.
