### PR TITLE
Issue #336 Issue reading column with multiple DATA_PAGE encodings

### DIFF
--- a/src/Parquet/Data/BasicDataTypeHandler.cs
+++ b/src/Parquet/Data/BasicDataTypeHandler.cs
@@ -94,13 +94,12 @@ namespace Parquet.Data
          parent.Num_children += 1;
       }
 
-      public virtual Array MergeDictionary(Array untypedDictionary, int[] indexes)
+      public virtual Array MergeDictionary(Array src, Array untypedDictionary, int[] indexes, int indexLength)
       {
          TSystemType[] dictionary = (TSystemType[])untypedDictionary;
-         int length = indexes.Length;
-         TSystemType[] result = new TSystemType[length];
+         TSystemType[] result = (TSystemType[])src ?? new TSystemType[indexes.Length];
 
-         for (int i = 0; i < length; i++)
+         for (int i = 0; i < indexLength; i++)
          {
             int index = indexes[i];
             TSystemType value = dictionary[index];

--- a/src/Parquet/Data/Concrete/ByteArrayDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/ByteArrayDataTypeHandler.cs
@@ -17,7 +17,7 @@ namespace Parquet.Data.Concrete
          throw new NotImplementedException();
       }
 
-      public override Array MergeDictionary(Array dictionary, int[] indexes)
+      public override Array MergeDictionary(Array src, Array dictionary, int[] indexes, int indexLength)
       {
          throw new NotImplementedException();
       }

--- a/src/Parquet/Data/DataColumn.cs
+++ b/src/Parquet/Data/DataColumn.cs
@@ -37,14 +37,14 @@ namespace Parquet.Data
          int[] definitionLevels, int maxDefinitionLevel,
          int[] repetitionLevels, int maxRepetitionLevel,
          Array dictionary,
-         int[] dictionaryIndexes) : this(field)
+         int[] dictionaryIndexes, int indexOffset) : this(field)
       {
          Data = definedData;
 
          // 1. Dictionary merge
          if (dictionary != null)
          {
-            Data = _dataTypeHandler.MergeDictionary(dictionary, dictionaryIndexes);
+            Data = _dataTypeHandler.MergeDictionary(Data, dictionary, dictionaryIndexes, indexOffset);
          }
 
          // 2. Apply definitions

--- a/src/Parquet/Data/IDataTypeHandler.cs
+++ b/src/Parquet/Data/IDataTypeHandler.cs
@@ -31,7 +31,7 @@ namespace Parquet.Data
 
       Array GetArray(int minCount, bool rent, bool isNullable);
 
-      Array MergeDictionary(Array dictionary, int[] indexes);
+      Array MergeDictionary(Array src, Array dictionary, int[] indexes, int indexLength);
 
       Array PackDefinitions(Array data, int maxDefinitionLevel, out int[] definitions, out int defiintionsLength);
 

--- a/src/Parquet/Data/NonDataDataTypeHandler.cs
+++ b/src/Parquet/Data/NonDataDataTypeHandler.cs
@@ -42,12 +42,12 @@ namespace Parquet.Data
          throw new NotSupportedException();
       }
 
-      public Array MergeDictionary(Array dictionary, int[] indexes)
+      public Array MergeDictionary(Array src, Array dictionary, int[] indexes, int indexLength)
       {
          throw new NotSupportedException();
       }
 
-      public Array PackDefinitions(Array data,  int maxDefiniionLevel, out int[] definitions, out int defiintionsLength)
+      public Array PackDefinitions(Array data, int maxDefiniionLevel, out int[] definitions, out int defiintionsLength)
       {
          throw new NotImplementedException();
       }

--- a/src/Parquet/File/DataColumnReader.cs
+++ b/src/Parquet/File/DataColumnReader.cs
@@ -84,7 +84,7 @@ namespace Parquet.File
 
          while (true)
          {
-            ReadDataPage(ph, colData, maxValues, ph.Data_page_header.Num_values);
+            ReadDataPage(ph, colData, maxValues);
 
             pagesRead++;
 
@@ -152,7 +152,7 @@ namespace Parquet.File
             .Min();
       }
 
-      private void ReadDataPage(Thrift.PageHeader ph, ColumnRawData cd, long maxValues, int actualValues)
+      private void ReadDataPage(Thrift.PageHeader ph, ColumnRawData cd, long maxValues)
       {
          using (Stream pageStream = OpenDataPageStream(ph))
          {
@@ -175,7 +175,7 @@ namespace Parquet.File
                   cd.definitionsOffset += ReadLevels(reader, _maxDefinitionLevel, cd.definitions, cd.definitionsOffset);
                }
 
-               ReadColumn(reader, ph.Data_page_header.Encoding, maxValues, actualValues,
+               ReadColumn(reader, ph.Data_page_header.Encoding, maxValues, ph.Data_page_header.Num_values,
                   ref cd.values, ref cd.valuesOffset,
                   ref cd.indexes, ref cd.indexesOffset);
             }

--- a/src/Parquet/File/DataColumnReader.cs
+++ b/src/Parquet/File/DataColumnReader.cs
@@ -210,7 +210,7 @@ namespace Parquet.File
 
             case Thrift.Encoding.PLAIN_DICTIONARY:
                if (indexes == null) indexes = new int[(int)maxValues];
-               ReadPlainDictionary(reader, maxValues, indexes, indexesOffset);
+               ReadPlainDictionary(reader, actualValues, indexes, indexesOffset);
                indexesOffset += actualValues;
                break;
 


### PR DESCRIPTION
### Fixes

Issue #336 Issue reading column with multiple DATA_PAGE encodings

### Description

Fixed count calculation of already read values.
MergeDictionary() no longer replaces the whole value array.

- [ ] I have included unit tests validating this fix.
- [ ] I have updated markdown documentation where required.
