### PR TITLE
When columns truncate, really we need a truncation identifier

### DIFF
--- a/src/Parquet.CLI/Program.cs
+++ b/src/Parquet.CLI/Program.cs
@@ -108,7 +108,7 @@ namespace Parquet.CLI
             LinePrimitive<int> displayMinWidth = cmd.Option<int>("-m|--min", Help.Command_ViewAll_Min, 5);
             LinePrimitive<bool> displayNulls = cmd.Option<bool>("-n|--nulls", Help.Command_ViewAll_Nulls, true);
             LinePrimitive<bool> displayTypes = cmd.Option<bool>("-t|--types", Help.Command_ViewAll_Types, true);
-            LinePrimitive<string> truncationIdentifier = cmd.Option<string>("-u|--truncate", Help.Command_ViewAll_Types, "...");
+            LinePrimitive<string> truncationIdentifier = cmd.Option<string>("-u|--truncate", Help.Command_ViewAll_Types, defaultValue: "...");
 
             cmd.OnExecute(() =>
             {
@@ -119,7 +119,7 @@ namespace Parquet.CLI
                   displayNulls = displayNulls,
                   displayTypes = displayTypes,
                   expandCells = expandCells,
-                  truncationIdentifier = truncationIdentifier,
+                  truncationIdentifier = truncationIdentifier.Value ?? "...",
                   displayReferences = false
                };
 


### PR DESCRIPTION
### Fixes
Any string column of sufficient length to overflow a maximum viewport column width will show a truncation identifier. This is currently null as CFP doesn't default the parameter as expected.

- [x] I have included unit tests validating this fix.
- [x] I have updated markdown documentation where required.
- [x] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/elastacloud/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).