### PR TITLE
updated parquet convert interface to support chunking of rowgroups with CLR types

### DIFF
--- a/src/Parquet/ParquetConvert.cs
+++ b/src/Parquet/ParquetConvert.cs
@@ -26,11 +26,12 @@ namespace Parquet
       /// <param name="compressionMethod"><see cref="CompressionMethod"/></param>
       /// <param name="rowGroupSize"></param>
       /// <param name="append">Add to the current stream</param>
+      /// <param name="options">the default parquet options</param>
       /// <returns></returns>
       public static Schema Serialize<T>(IEnumerable<T> objectInstances, Stream destination,
          Schema schema = null,
          CompressionMethod compressionMethod = CompressionMethod.Snappy,
-         int rowGroupSize = 5000, bool append = false)
+         int rowGroupSize = 5000, bool append = false, ParquetOptions options = null)
          where T : new()
       {
          if (objectInstances == null) throw new ArgumentNullException(nameof(objectInstances));
@@ -43,7 +44,7 @@ namespace Parquet
             schema = SchemaReflector.Reflect<T>();
          }
 
-         using (var writer = new ParquetWriter(schema, destination, null, append))
+         using (var writer = new ParquetWriter(schema, destination, options, append))
          {
             writer.CompressionMethod = compressionMethod;
 

--- a/src/Parquet/ParquetConvert.cs
+++ b/src/Parquet/ParquetConvert.cs
@@ -25,11 +25,12 @@ namespace Parquet
       /// </param>
       /// <param name="compressionMethod"><see cref="CompressionMethod"/></param>
       /// <param name="rowGroupSize"></param>
+      /// <param name="append">Add to the current stream</param>
       /// <returns></returns>
       public static Schema Serialize<T>(IEnumerable<T> objectInstances, Stream destination,
          Schema schema = null,
          CompressionMethod compressionMethod = CompressionMethod.Snappy,
-         int rowGroupSize = 5000)
+         int rowGroupSize = 5000, bool append = false)
          where T : new()
       {
          if (objectInstances == null) throw new ArgumentNullException(nameof(objectInstances));
@@ -42,7 +43,7 @@ namespace Parquet
             schema = SchemaReflector.Reflect<T>();
          }
 
-         using (var writer = new ParquetWriter(schema, destination))
+         using (var writer = new ParquetWriter(schema, destination, null, append))
          {
             writer.CompressionMethod = compressionMethod;
 


### PR DESCRIPTION
### Fixes

Issue #372 

### Description

Added an append flag overload to ParquetConvert.Serialise to enable streaming 

- [ ] I have included unit tests validating this fix.
- [ ] I have updated markdown documentation where required.
- [ ] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/elastacloud/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).