### PR TITLE
Fixes parquet limitations around empty and one-element lists

### DIFF
--- a/src/Parquet.Test/Rows/LazyColumnEnumeratorTest.cs
+++ b/src/Parquet.Test/Rows/LazyColumnEnumeratorTest.cs
@@ -116,5 +116,28 @@ namespace Parquet.Test.Rows
          Assert.Empty(topLevel[1].ToDataArray());
          Assert.Equal(2, topLevel[2].ToDataArray().Length);
       }
+
+      [Fact]
+      public void Single_element_in_list_of_elements_in_a_structure()
+      {
+         var dc = new DataColumn(new DataField<double>("leftCategoriesOrThreshold") { MaxRepetitionLevel = 1 },
+            new double[]
+            {
+               1.7,
+               4.9,
+               1.6
+            },
+            new int[]
+            {
+               0,
+               0,
+               0
+            });
+
+         var e = new LazyColumnEnumerator(dc);
+         List<LazyColumnEnumerator> topLevel = e.ToEnumeratorList();
+         Assert.Equal(3, topLevel.Count);
+         Assert.Equal(1, topLevel[0].ToDataArray().Length);
+      }
    }
 }

--- a/src/Parquet.Test/Rows/LazyColumnEnumeratorTest.cs
+++ b/src/Parquet.Test/Rows/LazyColumnEnumeratorTest.cs
@@ -137,7 +137,20 @@ namespace Parquet.Test.Rows
          var e = new LazyColumnEnumerator(dc);
          List<LazyColumnEnumerator> topLevel = e.ToEnumeratorList();
          Assert.Equal(3, topLevel.Count);
-         Assert.Equal(1, topLevel[0].ToDataArray().Length);
+
+         double[] list0 = (double[])topLevel[0].ToDataArray();
+         double[] list1 = (double[])topLevel[1].ToDataArray();
+         double[] list2 = (double[])topLevel[2].ToDataArray();
+
+         //three lists with one element
+         Assert.Single(list0);
+         Assert.Single(list1);
+         Assert.Single(list2);
+
+         //compare values
+         Assert.Equal(1.7, list0[0], 3);
+         Assert.Equal(4.9, list1[0], 3);
+         Assert.Equal(1.6, list2[0], 3);
       }
    }
 }


### PR DESCRIPTION
### Fixes

Issue #398 

### Description

Unfortunately parquet format doesn't allow to distinguish between an empty list and a list with one null element. This fix makes parquet-net behaviour similar to the parquet-mr.

- [x] I have included unit tests validating this fix.
- [x] I have updated markdown documentation where required.
- [x] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/elastacloud/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).