### PR TITLE
Close stream fix

### DIFF
--- a/src/Parquet.Test/ParquetReaderTest.cs
+++ b/src/Parquet.Test/ParquetReaderTest.cs
@@ -142,6 +142,27 @@ namespace Parquet.Test
          }
       }
 
+      [Fact]
+      public void ParquetReader_OpenFromFile_Close_Stream()
+      {
+         // copy a file to a temp location
+         var tempFile = Path.GetTempFileName();
+         using (var fr = OpenTestFile("map_simple.parquet"))
+         using (var fw = System.IO.File.OpenWrite(tempFile))
+         {
+            fr.CopyTo(fw);
+         }
+               
+         // open the copy
+         using (var reader = ParquetReader.OpenFromFile(tempFile))
+         {
+            // do nothing
+         }
+         
+         // now try to delete this temp file. If the stream is properly closed, this should succeed
+         System.IO.File.Delete(tempFile);
+      }
+
       class ReadableNonSeekableStream : DelegatedStream
       {
          public ReadableNonSeekableStream(Stream master) : base(master)

--- a/src/Parquet/ParquetReader.cs
+++ b/src/Parquet/ParquetReader.cs
@@ -34,7 +34,7 @@ namespace Parquet
       /// <exception cref="ArgumentNullException">input</exception>
       /// <exception cref="ArgumentException">stream must be readable and seekable - input</exception>
       /// <exception cref="IOException">not a Parquet file (size too small)</exception>
-      public ParquetReader(Stream input, ParquetOptions parquetOptions = null, bool leaveStreamOpen = true) : this(input, true)
+      public ParquetReader(Stream input, ParquetOptions parquetOptions = null, bool leaveStreamOpen = true) : this(input, leaveStreamOpen)
       {
          
          if (!input.CanRead || !input.CanSeek) throw new ArgumentException("stream must be readable and seekable", nameof(input));


### PR DESCRIPTION
### Fixes

Issue #407 

### Description

Just properly propagated the `leaveStreamOpen` flag down

- [X] I have included unit tests validating this fix.
- [X ] I have updated markdown documentation where required.
- [X ] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/elastacloud/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).