### PR TITLE
Update TypeCachingKey.cs

### DIFF
--- a/src/Parquet/Serialization/Values/TypeCachingKey.cs
+++ b/src/Parquet/Serialization/Values/TypeCachingKey.cs
@@ -24,5 +24,10 @@ namespace Parquet.Serialization.Values
 
          return ClassType.Equals(other.ClassType) && Field.Equals(other.Field);
       }
+      
+      public override int GetHashCode()
+      {
+         return 31 * ClassType.GetHashCode() + Field.GetHashCode();
+      }
    }
 }


### PR DESCRIPTION
Dictionary.TryGetValue compares HashCode first and than uses overriden Equals method (it leads to memory leak when run multiple times with same type)
https://referencesource.microsoft.com/#mscorlib/system/collections/generic/dictionary.cs,303

### Fixes

Issue #

### Description

desctiption goes here

- [ ] I have included unit tests validating this fix.
- [ ] I have updated markdown documentation where required.
- [ ] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/elastacloud/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).