### PR TITLE
Create proper empty parquet when serializing from empty enumerable

### DIFF
--- a/src/Parquet.Test/Serialisation/ParquetConvertTest.cs
+++ b/src/Parquet.Test/Serialisation/ParquetConvertTest.cs
@@ -69,6 +69,16 @@ namespace Parquet.Test.Serialisation
       }
 
       [Fact]
+      public void Serialize_deserialize_empty_enumerable()
+      {
+         IEnumerable<SimpleRepeated> structures = Enumerable.Empty<SimpleRepeated>();
+
+         SimpleRepeated[] s = ConvertSerialiseDeserialise(structures);
+   
+         Assert.Equal(0, s.Length);
+      }
+
+      [Fact]
       public void Serialize_structure_with_DateTime()
       {
          TestRoundTripSerialization<DateTime>(DateTime.UtcNow.RoundToSecond());

--- a/src/Parquet/ParquetWriter.cs
+++ b/src/Parquet/ParquetWriter.cs
@@ -113,10 +113,11 @@ namespace Parquet
       /// </summary>
       public void Dispose()
       {
-         if (!_dataWritten) return;
-
-         //update row count (on append add row count to existing metadata)
-         _footer.Add(_openedWriters.Sum(w => w.RowCount ?? 0));
+         if (_dataWritten)
+         {
+            //update row count (on append add row count to existing metadata)
+            _footer.Add(_openedWriters.Sum(w => w.RowCount ?? 0));
+         }
 
          //finalize file
          long size = _footer.Write(ThriftStream);

--- a/src/Parquet/Thrift/FileMetaData.cs
+++ b/src/Parquet/Thrift/FileMetaData.cs
@@ -92,6 +92,7 @@ namespace Parquet.Thrift
 
       public FileMetaData()
       {
+         this.Row_groups = new List<RowGroup>();
       }
 
       public FileMetaData(int version, List<SchemaElement> schema, long num_rows, List<RowGroup> row_groups) : this()


### PR DESCRIPTION
### Fixes
Properly serialized Enumerable.Empty<T> to empty parquet file.

### Description
When serializing Enumerable.Empty<T> to parquet generated file was corrupted and on deserialization resulted with exception: 
IOException: not a Parquet file (size too small)

- [x] I have included unit tests validating this fix.
- [ ] I have updated markdown documentation where required.
- [x] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/elastacloud/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).