### PR TITLE
Optimize string data type handler to not create byte array for every string read from file

### DIFF
--- a/src/Parquet/Data/Concrete/StringDataTypeHandler.cs
+++ b/src/Parquet/Data/Concrete/StringDataTypeHandler.cs
@@ -56,11 +56,10 @@ namespace Parquet.Data.Concrete
 
             int spanIdx = 0;
 
-            while(spanIdx < span.Length && destIdx < tdest.Length)
+            while (spanIdx < span.Length && destIdx < tdest.Length)
             {
                int length = span.Slice(spanIdx, 4).ReadInt32();
-               byte[] buffer = span.Slice(spanIdx + 4, length).ToArray();
-               string s = E.GetString(buffer, 0, length);
+               string s = E.GetString(allBytes, spanIdx + 4, length);
                tdest[destIdx++] = s;
                spanIdx = spanIdx + 4 + length;
             }
@@ -75,7 +74,7 @@ namespace Parquet.Data.Concrete
 
       protected override string ReadSingle(BinaryReader reader, Thrift.SchemaElement tse, int length)
       {
-         if(length == -1) length = reader.ReadInt32();
+         if (length == -1) length = reader.ReadInt32();
 
          byte[] data = reader.ReadBytes(length);
          return Encoding.UTF8.GetString(data);


### PR DESCRIPTION
Optimize string data type handler to not create byte array for every string read from file
### Fixes
Currently for every string read from the parquet file, a byte array is created. This creation is not required and data can be read directly for existing byte array in which whole page is read.

Issue #
Currently for every string read from the parquet file, a byte array is created.

- [ ] Since this is optimization of existing code, no new unit tests have been added as existing one should be good enough to find any regressions if any
- [ ] I have updated markdown documentation where required.
- [ ] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/elastacloud/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).