### PR TITLE
[Merged] Optimize page reading by not creating new array from bytes owner

### DIFF
--- a/src/Parquet/File/BytesOwner.cs
+++ b/src/Parquet/File/BytesOwner.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 
 namespace Parquet.File
 {
@@ -10,16 +11,32 @@ namespace Parquet.File
    class BytesOwner : IDisposable
    {
       private readonly byte[] _bytes;  //original memory buffer
+      private readonly int startOffset;
       private readonly Action<byte[]> _disposeAction;
 
-      public BytesOwner(byte[] bytes, Memory<byte> memory, Action<byte[]> disposeAction)
+      public BytesOwner(byte[] bytes, int startOffset, Memory<byte> memory, Action<byte[]> disposeAction)
       {
          _bytes = bytes ?? throw new ArgumentNullException(nameof(bytes));
+         this.startOffset = startOffset;
          Memory = memory;
          _disposeAction = disposeAction ?? throw new ArgumentNullException(nameof(disposeAction));
       }
 
       public Memory<byte> Memory { get; }
+
+      /// <summary>
+      /// Creates a stream from the current bytes data.
+      /// </summary>
+      /// <remarks>
+      /// Returned stream should be dispose before disposing current object.
+      /// </remarks>
+      /// <returns>
+      /// Stream for bytes represented by current bytes owner instance.
+      /// </returns>
+      public Stream ToStream()
+      {
+         return new MemoryStream(_bytes, startOffset, this.Memory.Length);
+      }
 
       public void Dispose()
       {

--- a/src/Parquet/File/DataColumnReader.cs
+++ b/src/Parquet/File/DataColumnReader.cs
@@ -173,7 +173,7 @@ namespace Parquet.File
          using (BytesOwner bytes = ReadPageData(ph))
          {
             //todo: this is ugly, but will be removed once other parts are migrated to System.Memory
-            using (var ms = new MemoryStream(bytes.Memory.ToArray()))
+            using (var ms = bytes.ToStream())
             {
                ParquetEventSource.Current.OpenDataPage(_dataField.Path, _thriftColumnChunk.Meta_data.Codec.ToString(), ms.Length);
 

--- a/src/Parquet/File/DataStreamFactory.cs
+++ b/src/Parquet/File/DataStreamFactory.cs
@@ -108,7 +108,7 @@ namespace Parquet.File
                throw new NotSupportedException("method: " + compressionMethod);
          }
 
-         return new BytesOwner(data, data.AsMemory(0, (int)uncompressedLength), d => BytesPool.Return(d));
+         return new BytesOwner(data, 0, data.AsMemory(0, (int)uncompressedLength), d => BytesPool.Return(d));
       }
    }
 }


### PR DESCRIPTION
Optimize page reading by not creating new array from bytes owner

Fixes
Currently for every page read a temporary byte array is created from System.Memory object in BytesOwner. This creation is not required and data can be read directly for existing byte array in which whole page is read.

Issue #
Currently for every page read a temporary byte array is created from System.Memory object in BytesOwner.

 Since this is optimization of existing code, no new unit tests have been added as existing one should be good enough to find any regressions if any
 I have updated markdown documentation where required.
 I understand that successful approval of my pull request requires reproducible tests as per Contribution Guideline.