### PR TITLE
Fix issue with repetition levels when having nested lists in a table (#458)

### DIFF
--- a/src/Parquet.Test/Rows/RowsModelTest.cs
+++ b/src/Parquet.Test/Rows/RowsModelTest.cs
@@ -389,6 +389,32 @@ namespace Parquet.Test.Rows
 
       }
 
+      [Fact]
+      public void List_of_lists_read_write_structures()
+      {
+         var t = new Table(
+             new DataField<int>("id"),
+             new ListField(
+                 "items",
+                 new StructField(
+                     "item",
+                     new DataField<int>("id"),
+                     new ListField(
+                         "values",
+                         new DataField<string>("value")))));
+
+         t.Add(0, new[]
+         {
+            new Row(0, new[] { "0,0,0", "0,0,1", "0,0,2" }),
+            new Row(1, new[] { "0,1,0", "0,1,1", "0,1,2" }),
+            new Row(2, new[] { "0,2,0", "0,2,1", "0,2,2" }),
+         });
+
+         Table t1 = WriteRead(t);
+         Assert.Equal(3, ((object[])t1[0][1]).Length);
+         Assert.Equal(t.ToString(), t1.ToString(), ignoreLineEndingDifferences: true);
+      }
+
       #endregion
 
       #region [ Mixed ]

--- a/src/Parquet/Data/Rows/DataColumnAppender.cs
+++ b/src/Parquet/Data/Rows/DataColumnAppender.cs
@@ -20,8 +20,9 @@ namespace Parquet.Data.Rows
          _isRepeated = dataField.MaxRepetitionLevel > 0;
       }
 
-      public void Add(object value, int level, int index)
+      public void Add(object value, int level, LevelIndex[] indexes)
       {
+         int index = indexes[indexes.Length - 1].Index;
          if (_isRepeated)
          {
             if(!(value is string) && value is IEnumerable valueItems)

--- a/src/Parquet/Data/Rows/DataColumnAppender.cs
+++ b/src/Parquet/Data/Rows/DataColumnAppender.cs
@@ -11,8 +11,7 @@ namespace Parquet.Data.Rows
       private readonly List<object> _values = new List<object>();
       private readonly List<int> _rls = new List<int>();
       private readonly bool _isRepeated;
-      private int _lastIndex;
-      private int _lastLevel;
+      private LevelIndex[] _lastIndixes;
 
       public DataColumnAppender(DataField dataField)
       {
@@ -22,12 +21,12 @@ namespace Parquet.Data.Rows
 
       public void Add(object value, int level, LevelIndex[] indexes)
       {
-         int index = indexes[indexes.Length - 1].Index;
          if (_isRepeated)
          {
-            if(!(value is string) && value is IEnumerable valueItems)
+            int rl = GetRepetitionLevel(indexes, _lastIndixes);
+
+            if (!(value is string) && value is IEnumerable valueItems)
             {
-               int rl = 0;
                int count = 0;
                foreach (object valueItem in (IEnumerable)value)
                {
@@ -46,14 +45,11 @@ namespace Parquet.Data.Rows
             }
             else
             {
-               int rl = index == 0 ? 0 : _dataField.MaxRepetitionLevel;
-
                _values.Add(value);
                _rls.Add(rl);
             }
 
-            _lastLevel = level;
-            _lastIndex = index;
+            _lastIndixes = indexes;
          }
          else
          {
@@ -76,5 +72,16 @@ namespace Parquet.Data.Rows
       }
 
       public override string ToString() => _dataField.ToString();
+
+      private static int GetRepetitionLevel(LevelIndex[] currentIndexes, LevelIndex[] lastIndexes)
+      {
+         for (int i = 0; i < (lastIndexes?.Length ?? 0); i++)
+         {
+            if (currentIndexes[i].Index != lastIndexes[i].Index)
+               return lastIndexes[i].Level;
+         }
+
+         return 0;
+      }
    }
 }

--- a/src/Parquet/Data/Rows/LevelIndex.cs
+++ b/src/Parquet/Data/Rows/LevelIndex.cs
@@ -1,0 +1,34 @@
+﻿namespace Parquet.Data.Rows
+{
+   struct LevelIndex
+   {
+      public LevelIndex(int level, int index)
+      {
+         Level = level;
+         Index = index;
+      }
+
+      public int Level { get; set; }
+      public int Index { get; set; }
+
+      public override string ToString()
+      {
+         return $"Level: {Level}; Index: {Index}";
+      }
+
+      public override bool Equals(object obj)
+      {
+         if (obj is LevelIndex li &&
+            li.Index == Index &&
+            li.Level == Level)
+               return true;
+
+         return false;
+      }
+
+      public override int GetHashCode()
+      {
+         return Level.GetHashCode() * 17 + Index.GetHashCode();
+      }
+   }
+}

--- a/src/Parquet/Data/Rows/RowsToDataColumnsConverter.cs
+++ b/src/Parquet/Data/Rows/RowsToDataColumnsConverter.cs
@@ -19,7 +19,7 @@ namespace Parquet.Data.Rows
 
       public IReadOnlyCollection<DataColumn> Convert()
       {
-         ProcessRows(_schema.Fields, _rows, 0);
+         ProcessRows(_schema.Fields, _rows, 0, Array.Empty<LevelIndex>());
 
          List<DataColumn> result = _schema.GetDataFields()
             .Select(df => _pathToDataColumn[df.Path].ToDataColumn())
@@ -28,16 +28,16 @@ namespace Parquet.Data.Rows
          return result;
       }
 
-      private void ProcessRows(IReadOnlyCollection<Field> fields, IReadOnlyCollection<Row> rows, int level)
+      private void ProcessRows(IReadOnlyCollection<Field> fields, IReadOnlyCollection<Row> rows, int level, LevelIndex[] indexes)
       {
          int i = 0;
-         foreach(Row row in rows)
+         foreach (Row row in rows)
          {
-            ProcessRow(fields, row, level, i++);
+            ProcessRow(fields, row, level, indexes.Append(new LevelIndex(level, i++)));
          }
       }
 
-      private void ProcessRow(IReadOnlyCollection<Field> fields, Row row, int level, int index)
+      private void ProcessRow(IReadOnlyCollection<Field> fields, Row row, int level, LevelIndex[] indexes)
       {
          int cellIndex = 0;
          foreach(Field f in fields)
@@ -45,19 +45,19 @@ namespace Parquet.Data.Rows
             switch (f.SchemaType)
             {
                case SchemaType.Data:
-                  ProcessDataValue(f, row[cellIndex], level, index);
+                  ProcessDataValue(f, row[cellIndex], level, indexes);
                   break;
 
                case SchemaType.Map:
-                  ProcessMap((MapField)f, (IReadOnlyCollection<Row>)row[cellIndex], level + 1);
+                  ProcessMap((MapField)f, (IReadOnlyCollection<Row>)row[cellIndex], level + 1, indexes);
                   break;
 
                case SchemaType.Struct:
-                  ProcessRow(((StructField)f).Fields, (Row)row[cellIndex], level + 1, index);
+                  ProcessRow(((StructField)f).Fields, (Row)row[cellIndex], level + 1, indexes);
                   break;
 
                case SchemaType.List:
-                  ProcessList((ListField)f, row[cellIndex], level + 1, index);
+                  ProcessList((ListField)f, row[cellIndex], level + 1, indexes);
                   break;
 
                default:
@@ -68,7 +68,7 @@ namespace Parquet.Data.Rows
          }
       }
 
-      private void ProcessMap(MapField mapField, IReadOnlyCollection<Row> mapRows, int level)
+      private void ProcessMap(MapField mapField, IReadOnlyCollection<Row> mapRows, int level, LevelIndex[] indexes)
       {
          var fields = new Field[] { mapField.Key, mapField.Value };
 
@@ -76,10 +76,10 @@ namespace Parquet.Data.Rows
          var valueCell = mapRows.Select(r => r[1]).ToList();
          var row = new Row(keyCell, valueCell);
 
-         ProcessRow(fields, row, level, 0);
+         ProcessRow(fields, row, level, indexes);
       }
 
-      private void ProcessList(ListField listField, object cellValue, int level, int index)
+      private void ProcessList(ListField listField, object cellValue, int level, LevelIndex[] indexes)
       {
          Field f = listField.Item;
 
@@ -87,17 +87,17 @@ namespace Parquet.Data.Rows
          {
             case SchemaType.Data:
                //list has a special case for simple elements where they are not wrapped in rows
-               ProcessDataValue(f, cellValue, level, index);
+               ProcessDataValue(f, cellValue, level, indexes);
                break;
             case SchemaType.Struct:
-               ProcessRows(((StructField)f).Fields, (IReadOnlyCollection<Row>)cellValue, level + 1);
+               ProcessRows(((StructField)f).Fields, (IReadOnlyCollection<Row>)cellValue, level, indexes);
                break;
             default:
                throw new NotSupportedException();
          }
       }
 
-      private void ProcessDataValue(Field f, object value, int level, int index)
+      private void ProcessDataValue(Field f, object value, int level, LevelIndex[] indexes)
       {
          //prepare value appender
          if(!_pathToDataColumn.TryGetValue(f.Path, out DataColumnAppender appender))
@@ -106,7 +106,7 @@ namespace Parquet.Data.Rows
             _pathToDataColumn[f.Path] = appender;
          }
 
-         appender.Add(value, level, index);
+         appender.Add(value, level, indexes);
       }
    }
 }

--- a/src/Parquet/Extensions/CollectionExtensions.cs
+++ b/src/Parquet/Extensions/CollectionExtensions.cs
@@ -116,5 +116,18 @@ namespace Parquet
 
          IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
       }
+
+      public static T[] Append<T>(this T[] array, T value)
+      {
+         int length = array?.Length ?? 0;
+         var newArray = new T[array.Length + 1];
+
+         if (length > 0)
+            array.CopyTo(newArray, 0);
+
+         newArray[newArray.Length - 1] = value;
+
+         return newArray;
+      }
    }
 }


### PR DESCRIPTION
### Fixes

Issue #458 

### Description

This PR fixes an issue with incorrect repetition levels when writing a table that has nested list fields. 

The suggested implementation uses an array of [LocationIndex](https://github.com/rickykaare/parquet-dotnet/blob/458-nested-listfields/src/Parquet/Data/Rows/LevelIndex.cs)s to keep track of the indexes of the lists at all preceding levels, and uses this information to identify which level is changing its index (repetition level).

Changes include:

* [bf382d8](https://github.com/rickykaare/parquet-dotnet/commit/bf382d87c15fbfb650dff5a3df520eee029f9693) Introduce LevelIndex to hold index information for each list in the path
* [58d87b0](https://github.com/rickykaare/parquet-dotnet/commit/58d87b0cef6fc91f446e5d98ab847d1f637d6ba7) Introduce extension method for appending values to an array
* [9a025e5](https://github.com/rickykaare/parquet-dotnet/commit/9a025e5a73cf907f4587fdef2e99622b95805774) Make level indexes available to the DataColumnAppender
* [b781927](https://github.com/rickykaare/parquet-dotnet/commit/b781927fd9a99f7ee5540832c644e9a3cd3bdb75) Calculate correct repetition levels based on which level changed its index
* [3a3020f](https://github.com/rickykaare/parquet-dotnet/commit/3a3020f0842dbb63bcef70a0c5e5083d727d4026) Add unit test for validating fix

- [x] I have included unit tests validating this fix.
- [x] I have updated markdown documentation where required.
- [x] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/elastacloud/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).