### PR TITLE
Make ClrType a public property in the DataField object.

### DIFF
--- a/src/Parquet/Data/Schema/DataField.cs
+++ b/src/Parquet/Data/Schema/DataField.cs
@@ -25,9 +25,9 @@ namespace Parquet.Data
       public bool IsArray { get; }
 
       /// <summary>
-      /// CLR type of this column. Not sure whether to expose this externally yet.
+      /// CLR type of this column.
       /// </summary>
-      internal Type ClrType { get; private set; }
+      public Type ClrType { get; private set; }
 
       internal Type ClrNullableIfHasNullsType { get; private set; }
 


### PR DESCRIPTION
### Fixes

Issue #455

### Description

Make ClrType a public property in the DataField object.
I did not add a test as this is a trivial change. Did not see any markdown to update.

- [ ] I have included unit tests validating this fix.
- [ ] I have updated markdown documentation where required.
- [x] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/elastacloud/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).