### PR TITLE
fix reading of plain dictionary with zero length

### DIFF
--- a/src/Parquet/File/DataColumnReader.cs
+++ b/src/Parquet/File/DataColumnReader.cs
@@ -208,7 +208,7 @@ namespace Parquet.File
       {
          int bitWidth = maxLevel.GetBitWidth();
 
-         return RunLengthBitPackingHybridValuesReader.ReadRleBitpackedHybrid(reader, bitWidth, 0, dest, offset, pageSize);
+         return RunLengthBitPackingHybridValuesReader.ReadRleBitpackedHybrid(reader, bitWidth, -1, dest, offset, pageSize);
       }
 
       private void ReadColumn(BinaryReader reader, Thrift.Encoding encoding, long totalValues, int maxReadCount, ColumnRawData cd)

--- a/src/Parquet/File/Values/RunLengthBitPackingHybridValuesReader.cs
+++ b/src/Parquet/File/Values/RunLengthBitPackingHybridValuesReader.cs
@@ -34,7 +34,7 @@ namespace Parquet.File.Values
 
       public static int ReadRleBitpackedHybrid(BinaryReader reader, int bitWidth, int length, int[] dest, int offset, int pageSize)
       {
-         if (length == 0) length = reader.ReadInt32();
+         if (length == -1) length = reader.ReadInt32();
 
          long start = reader.BaseStream.Position;
          int startOffset = offset;


### PR DESCRIPTION
### Fixes

Issue #476

The ReadRleBitpackedHybrid function interprets zero length as an instruction to read the actual length from the stream. ReadLevels relies on this behavior, however, zero can be a valid length when reading a plain dictionary page. 

### Description
There could be more profound solutions, here, I just changed 0 to -1


- [ ] I have included unit tests validating this fix.
- [ ] I have updated markdown documentation where required.
- [ ] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/elastacloud/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).