### PR TITLE
ParquetWriter.Dispose() can now be called multiple times

### DIFF
--- a/src/Parquet.Test/ParquetWriterTest.cs
+++ b/src/Parquet.Test/ParquetWriterTest.cs
@@ -164,6 +164,30 @@ namespace Parquet.Test
       }
 
       [Fact]
+      public void Lifecycle_allow_multiple_dispose_calls()
+      {
+         using (var ms = new MemoryStream())
+         {
+            var id = new DataField<int>("id");
+
+            var writer = new ParquetWriter(new Schema(id), ms);
+            ParquetRowGroupWriter rg = writer.CreateRowGroup();
+            rg.WriteColumn(new DataColumn(id, new[] { 1, 2, 3, 4 }));
+
+            rg.Dispose();
+            writer.Dispose();
+
+            long correctLength = ms.Length;
+
+            //extra dispose should not do anything further to stream
+            rg.Dispose();
+            writer.Dispose();
+
+            Assert.Equal(correctLength, ms.Length);
+         }
+      }
+
+      [Fact]
       public void FileMetadata_sets_num_rows_on_file_and_row_group()
       {
          var ms = new MemoryStream();

--- a/src/Parquet/ParquetWriter.cs
+++ b/src/Parquet/ParquetWriter.cs
@@ -16,6 +16,7 @@ namespace Parquet
       private ThriftFooter _footer;
       private readonly Schema _schema;
       private readonly ParquetOptions _formatOptions;
+      private bool _disposed;
       private bool _dataWritten;
       private readonly List<ParquetRowGroupWriter> _openedWriters = new List<ParquetRowGroupWriter>();
 
@@ -113,6 +114,8 @@ namespace Parquet
       /// </summary>
       public void Dispose()
       {
+         if (_disposed) return;
+
          if (_dataWritten)
          {
             //update row count (on append add row count to existing metadata)
@@ -130,6 +133,8 @@ namespace Parquet
 
          Writer.Flush();
          Stream.Flush();
+
+         _disposed = true;
       }
    }
 }


### PR DESCRIPTION
ParquetWriter.Dispose() can now be called multiple times without degenerate writes to the underlying stream.

### Fixes

Issue # Multiple calls to ParquetWriter.Dispose() cause degenerate writes to the underlying stream.

### Description

It should be possible to call Dispose() multiple times on an object without consequence.  The current implementation of ParquetWriter does not track its disposal state and will rewrite data to the stream every time Dispose() is called. 

- [x] I have included unit tests validating this fix.
- [x] I have updated markdown documentation where required.
- [x] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/elastacloud/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).